### PR TITLE
#29 feat: add extract_images tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ claude mcp add linear-toon -e LINEAR_API_KEY=lin_api_xxxxx -- linear-toon-mcp
 | `update_issue` | Update an existing Linear issue by ID. Supports partial updates, null to remove fields, and relation replacement. |
 | `create_comment` | Create a comment on a Linear issue. Supports Markdown content and threaded replies via parentId. |
 | `list_comments` | List comments for a specific Linear issue in chronological order. Returns each comment's id, body, author, and timestamps. |
+| `extract_images` | Extract and fetch images referenced in markdown (issue descriptions, comments). Parses Markdown and HTML `<img>` tags, downloads each unique URL, and returns the images as MCP image content so the LLM can view them inline. Sends the Linear API key only to `*.linear.app` hosts. |
 
 ## Development
 

--- a/lib/linear_toon_mcp.rb
+++ b/lib/linear_toon_mcp.rb
@@ -17,6 +17,7 @@ require_relative "linear_toon_mcp/tools/list_issue_labels"
 require_relative "linear_toon_mcp/tools/list_projects"
 require_relative "linear_toon_mcp/tools/list_cycles"
 require_relative "linear_toon_mcp/tools/get_project"
+require_relative "linear_toon_mcp/tools/extract_images"
 
 # Token-efficient MCP server for Linear. Wraps Linear's GraphQL API
 # and returns TOON-formatted responses for ~40-60% token savings.
@@ -32,7 +33,7 @@ module LinearToonMcp
       name: "linear-toon-mcp",
       version: VERSION,
       description: "Manage Linear issues, projects, and teams",
-      tools: [Tools::GetIssue, Tools::ListIssues, Tools::ListIssueStatuses, Tools::ListTeams, Tools::ListUsers, Tools::ListIssueLabels, Tools::ListProjects, Tools::ListCycles, Tools::GetProject, Tools::CreateComment, Tools::ListComments, Tools::CreateIssue, Tools::UpdateIssue],
+      tools: [Tools::GetIssue, Tools::ListIssues, Tools::ListIssueStatuses, Tools::ListTeams, Tools::ListUsers, Tools::ListIssueLabels, Tools::ListProjects, Tools::ListCycles, Tools::GetProject, Tools::CreateComment, Tools::ListComments, Tools::CreateIssue, Tools::UpdateIssue, Tools::ExtractImages],
       server_context: {client:}
     )
   end

--- a/lib/linear_toon_mcp/client.rb
+++ b/lib/linear_toon_mcp/client.rb
@@ -5,9 +5,14 @@ require "json"
 require "uri"
 
 module LinearToonMcp
-  # Minimal HTTP client for Linear's GraphQL API.
+  # Minimal HTTP client for Linear's GraphQL API and authenticated asset
+  # downloads (e.g. images hosted on +uploads.linear.app+).
   class Client
     ENDPOINT = URI("https://api.linear.app/graphql").freeze
+
+    # Hosts that receive the Linear API key as an +Authorization+ header.
+    # Other hosts are fetched unauthenticated to avoid leaking the key.
+    LINEAR_HOST_SUFFIX = ".linear.app"
 
     # @param api_key [String] Linear API key (defaults to +LINEAR_API_KEY+ env var)
     # @raise [ArgumentError] when API key is nil or empty
@@ -46,7 +51,41 @@ module LinearToonMcp
       body["data"]
     end
 
+    # Fetch a raw HTTP resource (used for downloading Linear asset URLs such
+    # as images embedded in issue descriptions). The Linear API key is only
+    # sent to +*.linear.app+ hosts so the credential never leaks to third
+    # parties referenced in user-provided markdown.
+    #
+    # @param url [String] absolute HTTP(S) URL to download
+    # @return [Net::HTTPResponse] the raw successful response
+    # @raise [Error] on invalid URLs, unsupported schemes, or HTTP failures
+    def fetch(url)
+      uri = begin
+        URI.parse(url)
+      rescue URI::InvalidURIError
+        raise Error, "Invalid URL: #{url}"
+      end
+
+      raise Error, "Unsupported URL scheme: #{uri.scheme.inspect}" unless %w[http https].include?(uri.scheme)
+      raise Error, "URL missing host: #{url}" if uri.host.nil? || uri.host.empty?
+
+      request = Net::HTTP::Get.new(uri)
+      request["Authorization"] = @api_key if linear_host?(uri.host)
+
+      response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https") do |http|
+        http.request(request)
+      end
+
+      raise Error, "HTTP #{response.code}: failed to fetch #{url}" unless response.is_a?(Net::HTTPSuccess)
+
+      response
+    end
+
     private
+
+    def linear_host?(host)
+      host == "linear.app" || host.end_with?(LINEAR_HOST_SUFFIX)
+    end
 
     def post(query_string, variables)
       request = Net::HTTP::Post.new(ENDPOINT)

--- a/lib/linear_toon_mcp/client.rb
+++ b/lib/linear_toon_mcp/client.rb
@@ -51,15 +51,49 @@ module LinearToonMcp
       body["data"]
     end
 
+    # Maximum number of HTTP redirects to follow before giving up.
+    MAX_REDIRECTS = 5
+
     # Fetch a raw HTTP resource (used for downloading Linear asset URLs such
     # as images embedded in issue descriptions). The Linear API key is only
     # sent to +*.linear.app+ hosts so the credential never leaks to third
-    # parties referenced in user-provided markdown.
+    # parties referenced in user-provided markdown. Follows up to
+    # {MAX_REDIRECTS} redirects automatically.
     #
     # @param url [String] absolute HTTP(S) URL to download
     # @return [Net::HTTPResponse] the raw successful response
-    # @raise [Error] on invalid URLs, unsupported schemes, or HTTP failures
+    # @raise [Error] on invalid URLs, unsupported schemes, too many redirects,
+    #   or HTTP failures
     def fetch(url)
+      uri = parse_fetch_uri(url)
+      redirects = 0
+
+      loop do
+        request = Net::HTTP::Get.new(uri)
+        request["Authorization"] = @api_key if linear_host?(uri.host)
+
+        response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https") do |http|
+          http.request(request)
+        end
+
+        return response if response.is_a?(Net::HTTPSuccess)
+
+        if response.is_a?(Net::HTTPRedirection)
+          location = response["Location"]
+          raise Error, "Redirect without Location header for #{url}" unless location
+          redirects += 1
+          raise Error, "Too many redirects for #{url}" if redirects > MAX_REDIRECTS
+          uri = parse_fetch_uri(location)
+          next
+        end
+
+        raise Error, "HTTP #{response.code}: failed to fetch #{url}"
+      end
+    end
+
+    private
+
+    def parse_fetch_uri(url)
       uri = begin
         URI.parse(url)
       rescue URI::InvalidURIError
@@ -69,19 +103,8 @@ module LinearToonMcp
       raise Error, "Unsupported URL scheme: #{uri.scheme.inspect}" unless %w[http https].include?(uri.scheme)
       raise Error, "URL missing host: #{url}" if uri.host.nil? || uri.host.empty?
 
-      request = Net::HTTP::Get.new(uri)
-      request["Authorization"] = @api_key if linear_host?(uri.host)
-
-      response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https") do |http|
-        http.request(request)
-      end
-
-      raise Error, "HTTP #{response.code}: failed to fetch #{url}" unless response.is_a?(Net::HTTPSuccess)
-
-      response
+      uri
     end
-
-    private
 
     def linear_host?(host)
       host == "linear.app" || host.end_with?(LINEAR_HOST_SUFFIX)

--- a/lib/linear_toon_mcp/tools/extract_images.rb
+++ b/lib/linear_toon_mcp/tools/extract_images.rb
@@ -87,6 +87,8 @@ module LinearToonMcp
             images << fetch_image(client, url)
           rescue Error => e
             failures << "#{url}: #{e.message}"
+          rescue => e
+            failures << "#{url}: #{e.class}: #{e.message}"
           end
 
           [images, failures]

--- a/lib/linear_toon_mcp/tools/extract_images.rb
+++ b/lib/linear_toon_mcp/tools/extract_images.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require "base64"
+
+module LinearToonMcp
+  module Tools
+    # Extract and fetch images referenced in markdown content such as Linear
+    # issue descriptions or comments. Parses both Markdown image syntax and
+    # HTML +<img>+ tags, downloads each unique URL via the Linear client, and
+    # returns the images as MCP image content so an LLM can view them inline.
+    #
+    # A short text summary is prepended to the response listing how many
+    # images were fetched successfully and any per-URL failures.
+    class ExtractImages < MCP::Tool
+      description "Extract and fetch images referenced in markdown content"
+
+      annotations(
+        read_only_hint: true,
+        destructive_hint: false,
+        idempotent_hint: true
+      )
+
+      input_schema(
+        properties: {
+          markdown: {
+            type: "string",
+            description: "Markdown content containing image references"
+          }
+        },
+        required: ["markdown"],
+        additionalProperties: false
+      )
+
+      SUPPORTED_MIME_TYPES = %w[image/png image/jpeg image/gif image/webp].freeze
+
+      EXTENSION_MIME_TYPES = {
+        ".png" => "image/png",
+        ".jpg" => "image/jpeg",
+        ".jpeg" => "image/jpeg",
+        ".gif" => "image/gif",
+        ".webp" => "image/webp"
+      }.freeze
+
+      MARKDOWN_IMAGE_REGEX = /!\[[^\]]*\]\(\s*([^)\s]+)(?:\s+"[^"]*")?\s*\)/
+      HTML_IMAGE_REGEX = /<img\b[^>]*?\bsrc\s*=\s*["']([^"']+)["']/i
+
+      class << self
+        # @param markdown [String] markdown content that may reference images
+        # @param server_context [Hash, nil] must contain +:client+ key with a {Client}
+        # @return [MCP::Tool::Response] text summary followed by fetched images,
+        #   or an error response when the client is missing
+        def call(markdown:, server_context: nil)
+          client = server_context&.dig(:client) or raise Error, "client missing from server_context"
+
+          urls = extract_urls(markdown)
+          return MCP::Tool::Response.new([{type: "text", text: "No images found in markdown"}]) if urls.empty?
+
+          images, failures = fetch_all(client, urls)
+
+          content = [{type: "text", text: build_summary(urls.size, images.size, failures)}]
+          content.concat(images)
+          MCP::Tool::Response.new(content)
+        rescue Error => e
+          MCP::Tool::Response.new([{type: "text", text: e.message}], error: true)
+        end
+
+        private
+
+        # Extract unique image URLs from Markdown and HTML image tags.
+        # Preserves the order of first appearance.
+        def extract_urls(markdown)
+          return [] if markdown.nil? || markdown.empty?
+
+          urls = []
+          markdown.scan(MARKDOWN_IMAGE_REGEX) { |match| urls << match[0] }
+          markdown.scan(HTML_IMAGE_REGEX) { |match| urls << match[0] }
+          urls.uniq
+        end
+
+        # Fetch every URL and partition the results into image content items
+        # and failure messages keyed by URL.
+        def fetch_all(client, urls)
+          images = []
+          failures = []
+
+          urls.each do |url|
+            images << fetch_image(client, url)
+          rescue Error => e
+            failures << "#{url}: #{e.message}"
+          end
+
+          [images, failures]
+        end
+
+        # Fetch a single image and build an MCP image content hash.
+        # @raise [Error] when the MIME type is not supported by MCP image content
+        def fetch_image(client, url)
+          response = client.fetch(url)
+          mime_type = resolve_mime_type(response, url)
+          raise Error, "unsupported content type: #{mime_type || "unknown"}" unless SUPPORTED_MIME_TYPES.include?(mime_type)
+
+          {
+            type: "image",
+            data: Base64.strict_encode64(response.body.to_s),
+            mimeType: mime_type
+          }
+        end
+
+        # Resolve a MIME type from the response Content-Type header, falling
+        # back to the URL's file extension when the header is missing or
+        # uninformative.
+        def resolve_mime_type(response, url)
+          header = response["Content-Type"]&.split(";")&.first&.strip&.downcase
+          return header if header && SUPPORTED_MIME_TYPES.include?(header)
+
+          ext = File.extname(URI.parse(url).path).downcase
+          EXTENSION_MIME_TYPES[ext] || header
+        rescue URI::InvalidURIError
+          header
+        end
+
+        def build_summary(total, fetched, failures)
+          summary = "Fetched #{fetched} of #{total} images"
+          summary += "\nFailures:\n- #{failures.join("\n- ")}" if failures.any?
+          summary
+        end
+      end
+    end
+  end
+end

--- a/lib/linear_toon_mcp/version.rb
+++ b/lib/linear_toon_mcp/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LinearToonMcp
-  VERSION = "0.6.0"
+  VERSION = "0.7.0"
 end

--- a/linear-toon-mcp.gemspec
+++ b/linear-toon-mcp.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.executables = ["linear-toon-mcp"]
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "base64", "~> 0.2" # bundled gem since Ruby 3.4; used for image encoding
   spec.add_dependency "mcp", "~> 0.11"
   spec.add_dependency "openssl", ">= 3.3.1" # CRL verification fix for Linear API SSL
   spec.add_dependency "toon-ruby", "~> 0.1"

--- a/spec/linear_toon_mcp/client_spec.rb
+++ b/spec/linear_toon_mcp/client_spec.rb
@@ -74,4 +74,88 @@ RSpec.describe LinearToonMcp::Client do
       allow(Net::HTTP).to receive(:start).and_return(response)
     end
   end
+
+  describe "#fetch" do
+    subject(:client) { described_class.new(api_key: "test_key") }
+
+    let(:captured_request) { {} }
+
+    def stub_fetch(body: "BINARY", code: "200")
+      response = Net::HTTPResponse::CODE_TO_OBJ[code].new("1.1", code, "")
+      allow(response).to receive(:body).and_return(body)
+      allow(Net::HTTP).to receive(:start) do |_host, _port, **_opts, &block|
+        http = instance_double(Net::HTTP)
+        allow(http).to receive(:request) do |request|
+          captured_request[:authorization] = request["Authorization"]
+          captured_request[:method] = request.method
+          captured_request[:uri] = request.uri
+          response
+        end
+        block.call(http)
+      end
+      response
+    end
+
+    it "returns the HTTP response on success" do
+      stub_fetch(body: "IMAGE_BYTES")
+
+      response = client.fetch("https://uploads.linear.app/abc.png")
+
+      expect(response.body).to eq("IMAGE_BYTES")
+    end
+
+    it "sends the Linear API key for uploads.linear.app hosts" do
+      stub_fetch
+
+      client.fetch("https://uploads.linear.app/abc.png")
+
+      expect(captured_request[:authorization]).to eq("test_key")
+    end
+
+    it "sends the Linear API key for the linear.app apex host" do
+      stub_fetch
+
+      client.fetch("https://linear.app/foo.png")
+
+      expect(captured_request[:authorization]).to eq("test_key")
+    end
+
+    it "does not send the Linear API key to third-party hosts" do
+      stub_fetch
+
+      client.fetch("https://example.com/image.png")
+
+      expect(captured_request[:authorization]).to be_nil
+    end
+
+    it "does not treat a host ending in linear.app within a larger domain as Linear" do
+      stub_fetch
+
+      client.fetch("https://evil-linear.app/image.png")
+
+      expect(captured_request[:authorization]).to be_nil
+    end
+
+    it "raises when the response is not successful" do
+      stub_fetch(body: "Not Found", code: "404")
+
+      expect { client.fetch("https://uploads.linear.app/missing.png") }
+        .to raise_error(LinearToonMcp::Error, /HTTP 404/)
+    end
+
+    it "raises on unsupported URL schemes" do
+      expect { client.fetch("file:///etc/passwd") }
+        .to raise_error(LinearToonMcp::Error, /Unsupported URL scheme/)
+    end
+
+    it "raises when the URL is missing a host" do
+      expect { client.fetch("https:///no-host") }
+        .to raise_error(LinearToonMcp::Error, /URL missing host/)
+    end
+
+    it "raises on a malformed URL" do
+      expect { client.fetch("http://[::bad uri") }
+        .to raise_error(LinearToonMcp::Error, /Invalid URL/)
+    end
+  end
 end

--- a/spec/linear_toon_mcp/client_spec.rb
+++ b/spec/linear_toon_mcp/client_spec.rb
@@ -157,5 +157,77 @@ RSpec.describe LinearToonMcp::Client do
       expect { client.fetch("http://[::bad uri") }
         .to raise_error(LinearToonMcp::Error, /Invalid URL/)
     end
+
+    context "when the server returns a redirect" do
+      def stub_redirect_chain(*responses_config)
+        call_count = 0
+        allow(Net::HTTP).to receive(:start) do |_host, _port, **_opts, &block|
+          config = responses_config[call_count] || responses_config.last
+          call_count += 1
+          code = config[:code]
+          response = Net::HTTPResponse::CODE_TO_OBJ[code].new("1.1", code, "")
+          allow(response).to receive(:body).and_return(config[:body] || "")
+          allow(response).to receive(:[]).and_call_original
+          allow(response).to receive(:[]).with("Location").and_return(config[:location])
+          http = instance_double(Net::HTTP)
+          allow(http).to receive(:request) do |request|
+            captured_request[:authorization] = request["Authorization"]
+            response
+          end
+          block.call(http)
+        end
+      end
+
+      it "follows a 302 redirect and returns the final response" do
+        stub_redirect_chain(
+          {code: "302", location: "https://cdn.example.com/real.png"},
+          {code: "200", body: "IMAGE"}
+        )
+
+        response = client.fetch("https://uploads.linear.app/redirect.png")
+
+        expect(response.body).to eq("IMAGE")
+      end
+
+      it "follows a 301 redirect" do
+        stub_redirect_chain(
+          {code: "301", location: "https://cdn.example.com/moved.png"},
+          {code: "200", body: "MOVED"}
+        )
+
+        response = client.fetch("https://uploads.linear.app/old.png")
+
+        expect(response.body).to eq("MOVED")
+      end
+
+      it "does not send API key to a third-party redirect target" do
+        stub_redirect_chain(
+          {code: "302", location: "https://cdn.example.com/img.png"},
+          {code: "200", body: "IMG"}
+        )
+
+        client.fetch("https://uploads.linear.app/redir.png")
+
+        expect(captured_request[:authorization]).to be_nil
+      end
+
+      it "raises when too many redirects are followed" do
+        stub_redirect_chain(
+          {code: "302", location: "https://example.com/loop"}
+        )
+
+        expect { client.fetch("https://example.com/loop") }
+          .to raise_error(LinearToonMcp::Error, /Too many redirects/)
+      end
+
+      it "raises when a redirect has no Location header" do
+        stub_redirect_chain(
+          {code: "302", location: nil}
+        )
+
+        expect { client.fetch("https://example.com/bad-redir") }
+          .to raise_error(LinearToonMcp::Error, /Redirect without Location/)
+      end
+    end
   end
 end

--- a/spec/linear_toon_mcp/server_spec.rb
+++ b/spec/linear_toon_mcp/server_spec.rb
@@ -40,7 +40,8 @@ RSpec.describe LinearToonMcp, ".server" do
         include(name: "create_comment", description: "Create a comment on a Linear issue"),
         include(name: "list_comments", description: "List comments for a specific Linear issue"),
         include(name: "create_issue", description: "Create a new Linear issue"),
-        include(name: "update_issue", description: "Update an existing Linear issue")
+        include(name: "update_issue", description: "Update an existing Linear issue"),
+        include(name: "extract_images", description: "Extract and fetch images referenced in markdown content")
       )
     end
   end

--- a/spec/linear_toon_mcp/tools/extract_images_spec.rb
+++ b/spec/linear_toon_mcp/tools/extract_images_spec.rb
@@ -199,6 +199,34 @@ RSpec.describe LinearToonMcp::Tools::ExtractImages do
       end
     end
 
+    context "when fetching an image raises a network-level exception" do
+      let(:markdown) { "![dns](https://uploads.linear.app/dns-fail.png)" }
+
+      before do
+        allow(client).to receive(:fetch).and_raise(SocketError, "getaddrinfo: Name or service not known")
+      end
+
+      it "collects the error as a per-image failure instead of crashing" do
+        expect(response).not_to be_error
+        expect(response.content.first[:text]).to include("Fetched 0 of 1")
+        expect(response.content.first[:text]).to include("SocketError")
+      end
+    end
+
+    context "when fetching an image raises a timeout" do
+      let(:markdown) { "![slow](https://uploads.linear.app/slow.png)" }
+
+      before do
+        allow(client).to receive(:fetch).and_raise(Net::OpenTimeout, "execution expired")
+      end
+
+      it "collects the timeout as a per-image failure instead of crashing" do
+        expect(response).not_to be_error
+        expect(response.content.first[:text]).to include("Fetched 0 of 1")
+        expect(response.content.first[:text]).to include("Net::OpenTimeout")
+      end
+    end
+
     context "when server_context has no client" do
       subject(:response) { described_class.call(markdown: "![](x.png)", server_context: {}) }
 

--- a/spec/linear_toon_mcp/tools/extract_images_spec.rb
+++ b/spec/linear_toon_mcp/tools/extract_images_spec.rb
@@ -1,0 +1,220 @@
+# frozen_string_literal: true
+
+require "base64"
+
+RSpec.describe LinearToonMcp::Tools::ExtractImages do
+  describe ".call" do
+    subject(:response) { described_class.call(markdown:, server_context: {client:}) }
+
+    let(:client) { instance_double(LinearToonMcp::Client) }
+    let(:markdown) { "no images here" }
+
+    def mock_http_response(body:, content_type: "image/png")
+      response = instance_double(Net::HTTPOK, body: body.b)
+      allow(response).to receive(:[]).with("Content-Type").and_return(content_type)
+      response
+    end
+
+    context "when the markdown contains no images" do
+      it "returns a single text block explaining no images were found" do
+        expect(response).to be_a(MCP::Tool::Response)
+        expect(response).not_to be_error
+        expect(response.content.length).to eq(1)
+        expect(response.content.first).to include(type: "text")
+        expect(response.content.first[:text]).to include("No images")
+      end
+
+      it "does not call the client" do
+        response
+        expect(client).not_to have_received(:fetch) if client.respond_to?(:fetch)
+      end
+    end
+
+    context "when the markdown contains a single markdown image" do
+      let(:markdown) { "some text ![screenshot](https://uploads.linear.app/abc/screenshot.png) more text" }
+      let(:png_bytes) { "\x89PNG\r\n\x1a\nFAKE" }
+
+      before do
+        allow(client).to receive(:fetch)
+          .with("https://uploads.linear.app/abc/screenshot.png")
+          .and_return(mock_http_response(body: png_bytes))
+      end
+
+      it "returns a summary followed by an image content block" do
+        expect(response).not_to be_error
+        expect(response.content.length).to eq(2)
+        expect(response.content.first[:text]).to include("Fetched 1 of 1")
+        expect(response.content.last).to eq(
+          type: "image",
+          data: Base64.strict_encode64(png_bytes.b),
+          mimeType: "image/png"
+        )
+      end
+    end
+
+    context "when the markdown contains an HTML <img> tag" do
+      let(:markdown) { %(<img src="https://uploads.linear.app/x.jpg" alt="x" />) }
+      let(:jpg_bytes) { "JPGBINARY" }
+
+      before do
+        allow(client).to receive(:fetch)
+          .with("https://uploads.linear.app/x.jpg")
+          .and_return(mock_http_response(body: jpg_bytes, content_type: "image/jpeg"))
+      end
+
+      it "fetches the image and returns it as jpeg content" do
+        expect(response.content.last).to include(type: "image", mimeType: "image/jpeg")
+        expect(response.content.last[:data]).to eq(Base64.strict_encode64(jpg_bytes.b))
+      end
+    end
+
+    context "when the markdown contains a markdown image with a title" do
+      let(:markdown) { %(![alt](https://uploads.linear.app/t.png "title text")) }
+
+      before do
+        allow(client).to receive(:fetch)
+          .with("https://uploads.linear.app/t.png")
+          .and_return(mock_http_response(body: "PNGDATA"))
+      end
+
+      it "parses the URL without the trailing title" do
+        response
+        expect(client).to have_received(:fetch).with("https://uploads.linear.app/t.png")
+      end
+    end
+
+    context "when the same image URL appears multiple times" do
+      let(:markdown) do
+        <<~MD
+          ![one](https://uploads.linear.app/dup.png)
+          <img src="https://uploads.linear.app/dup.png" />
+          ![two](https://uploads.linear.app/dup.png)
+        MD
+      end
+
+      before do
+        allow(client).to receive(:fetch).and_return(mock_http_response(body: "DUP"))
+      end
+
+      it "fetches each unique URL exactly once" do
+        response
+        expect(client).to have_received(:fetch).with("https://uploads.linear.app/dup.png").once
+      end
+
+      it "returns a single image content block" do
+        expect(response.content.count { |c| c[:type] == "image" }).to eq(1)
+      end
+    end
+
+    context "when the markdown contains both markdown and HTML images" do
+      let(:markdown) do
+        <<~MD
+          ![a](https://uploads.linear.app/a.png)
+          <img src="https://uploads.linear.app/b.gif" />
+        MD
+      end
+
+      before do
+        allow(client).to receive(:fetch)
+          .with("https://uploads.linear.app/a.png")
+          .and_return(mock_http_response(body: "APNG", content_type: "image/png"))
+        allow(client).to receive(:fetch)
+          .with("https://uploads.linear.app/b.gif")
+          .and_return(mock_http_response(body: "BGIF", content_type: "image/gif"))
+      end
+
+      it "returns both images and a summary counting both" do
+        expect(response.content.first[:text]).to include("Fetched 2 of 2")
+        mime_types = response.content.select { |c| c[:type] == "image" }.map { |c| c[:mimeType] }
+        expect(mime_types).to contain_exactly("image/png", "image/gif")
+      end
+    end
+
+    context "when fetching an image raises a client error" do
+      let(:markdown) { "![bad](https://uploads.linear.app/bad.png)" }
+
+      before do
+        allow(client).to receive(:fetch).and_raise(LinearToonMcp::Error, "HTTP 404: failed to fetch")
+      end
+
+      it "reports the failure in the summary and does not raise" do
+        expect(response).not_to be_error
+        expect(response.content.first[:text]).to include("Fetched 0 of 1")
+        expect(response.content.first[:text]).to include("HTTP 404")
+      end
+
+      it "does not include a broken image content block" do
+        expect(response.content.any? { |c| c[:type] == "image" }).to be(false)
+      end
+    end
+
+    context "when one image succeeds and another fails" do
+      let(:markdown) do
+        <<~MD
+          ![good](https://uploads.linear.app/good.png)
+          ![bad](https://uploads.linear.app/bad.png)
+        MD
+      end
+
+      before do
+        allow(client).to receive(:fetch)
+          .with("https://uploads.linear.app/good.png")
+          .and_return(mock_http_response(body: "GOOD"))
+        allow(client).to receive(:fetch)
+          .with("https://uploads.linear.app/bad.png")
+          .and_raise(LinearToonMcp::Error, "HTTP 500: failed to fetch")
+      end
+
+      it "includes the successful image and reports the failed URL" do
+        expect(response).not_to be_error
+        expect(response.content.first[:text]).to include("Fetched 1 of 2")
+        expect(response.content.first[:text]).to include("https://uploads.linear.app/bad.png")
+        expect(response.content.count { |c| c[:type] == "image" }).to eq(1)
+      end
+    end
+
+    context "when the image has an unsupported MIME type" do
+      let(:markdown) { "![svg](https://uploads.linear.app/vector.svg)" }
+
+      before do
+        allow(client).to receive(:fetch)
+          .and_return(mock_http_response(body: "<svg></svg>", content_type: "image/svg+xml"))
+      end
+
+      it "reports the unsupported content type in the summary" do
+        expect(response.content.first[:text]).to include("unsupported")
+      end
+    end
+
+    context "when Content-Type is missing but the URL has a known extension" do
+      let(:markdown) { "![](https://uploads.linear.app/photo.webp)" }
+
+      before do
+        allow(client).to receive(:fetch)
+          .and_return(mock_http_response(body: "WEBPDATA", content_type: nil))
+      end
+
+      it "falls back to the extension for MIME type detection" do
+        expect(response.content.last).to include(type: "image", mimeType: "image/webp")
+      end
+    end
+
+    context "when server_context has no client" do
+      subject(:response) { described_class.call(markdown: "![](x.png)", server_context: {}) }
+
+      it "returns an error response" do
+        expect(response).to be_a(MCP::Tool::Response).and be_error
+        expect(response.content.first[:text]).to include("client missing")
+      end
+    end
+
+    context "when markdown is an empty string" do
+      let(:markdown) { "" }
+
+      it "returns the no-images message" do
+        expect(response).not_to be_error
+        expect(response.content.first[:text]).to include("No images")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds the `extract_images` tool that parses image references out of markdown (issue descriptions, comments) and returns the fetched images as MCP image content so the LLM can view them inline — no more falling back to the official Linear MCP just to see a screenshot.

- Parses both Markdown `![alt](url)` syntax and HTML `<img src>` tags, dedupes URLs while preserving order.
- New `Client#fetch(url)` performs the binary GET. The Linear API key is only sent to `*.linear.app` hosts so the credential never leaks to third-party URLs.
- Per-image failures (HTTP errors, unsupported MIME types) are collected into the summary text block instead of aborting the whole call — a broken screenshot never blocks the others.
- Supported MIME types: `image/png`, `image/jpeg`, `image/gif`, `image/webp`. Falls back to the URL extension when the response `Content-Type` is missing.
- `base64` is now declared in the gemspec (bundled gem in Ruby 3.4+).
- Version bumped to `0.7.0` and the Tools table in `README.md` is updated.

Closes #29.

## Test plan

- [x] `bundle exec rspec` — 217 examples, 0 failures
- [x] `bundle exec standardrb` — clean
- [x] New `ExtractImages` spec covers: markdown image, HTML img, titles, dedupe, mixed sources, single failure, partial success, unsupported MIME, Content-Type fallback, empty markdown, missing client
- [x] New `Client#fetch` spec covers: success, auth scoped to `*.linear.app`, no auth on third-party hosts, apex `linear.app`, suffix spoofing (`evil-linear.app`), HTTP failure, unsupported scheme, missing host, malformed URL
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new HTTP download path and URL parsing/redirect handling, which could impact security (credential leakage prevention) and reliability when fetching untrusted URLs.
> 
> **Overview**
> Adds a new `extract_images` MCP tool that scans Markdown/HTML for image URLs, downloads and base64-encodes supported image types, and returns them as MCP `image` content with a summary of successes/failures.
> 
> Extends `Client` with `#fetch` to GET arbitrary HTTP(S) URLs with redirect support while only attaching the Linear API key to `*.linear.app` hosts, and wires the tool into the server/tool list. Updates docs, bumps version to `0.7.0`, adds the `base64` gem dependency, and includes comprehensive specs for the new tool and fetch behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 708fbeda984d012392bb182ec73bdced097bb44a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->