### PR TITLE
#34 feat: expose parent and children on get_issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ claude mcp add linear-toon -e LINEAR_API_KEY=lin_api_xxxxx -- linear-toon-mcp
 
 | Tool | Description |
 |------|-------------|
-| `get_issue` | Retrieve a Linear issue by ID or identifier (e.g., `LIN-123`). Returns issue details including title, description, state, assignee, labels, project, and attachments. |
+| `get_issue` | Retrieve a Linear issue by ID or identifier (e.g., `LIN-123`). Returns issue details including title, description, state, assignee, labels, project, attachments, and the parent and direct child issues (each with identifier, title, state, and url). |
 | `list_issues` | List issues with optional filters (team, assignee, state, label, priority, project, cycle) and cursor-based pagination. Supports name or UUID for most filters. |
 | `list_issue_statuses` | List available workflow states for a team. Returns status id, type (backlog/unstarted/started/completed/canceled), and name. Accepts team name or UUID. |
 | `list_teams` | List all teams in the workspace. Returns team id, name, and key. |

--- a/lib/linear_toon_mcp/tools/get_issue.rb
+++ b/lib/linear_toon_mcp/tools/get_issue.rb
@@ -5,7 +5,8 @@ require "toon"
 module LinearToonMcp
   module Tools
     # Fetch a single Linear issue by ID or identifier and return it as TOON.
-    # Includes metadata, state, assignee, labels, project, team, and attachments.
+    # Includes metadata, state, assignee, labels, project, team, attachments,
+    # parent issue, and direct child issues.
     class GetIssue < MCP::Tool
       description "Retrieve a Linear issue by ID"
 
@@ -46,6 +47,8 @@ module LinearToonMcp
             project { id name }
             team { id name }
             attachments { nodes { id title url } }
+            parent { identifier title url state { name } }
+            children { nodes { identifier title url state { name } } }
           }
         }
       GRAPHQL

--- a/lib/linear_toon_mcp/tools/get_issue.rb
+++ b/lib/linear_toon_mcp/tools/get_issue.rb
@@ -8,7 +8,7 @@ module LinearToonMcp
     # Includes metadata, state, assignee, labels, project, team, attachments,
     # parent issue, and direct child issues.
     class GetIssue < MCP::Tool
-      description "Retrieve a Linear issue by ID"
+      description "Retrieve a Linear issue by ID, including its parent and direct child issues"
 
       annotations(
         read_only_hint: true,
@@ -48,7 +48,7 @@ module LinearToonMcp
             team { id name }
             attachments { nodes { id title url } }
             parent { identifier title url state { name } }
-            children { nodes { identifier title url state { name } } }
+            children(first: 50) { nodes { identifier title url state { name } } }
           }
         }
       GRAPHQL

--- a/spec/linear_toon_mcp/server_spec.rb
+++ b/spec/linear_toon_mcp/server_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe LinearToonMcp, ".server" do
 
     it "lists all tools" do
       expect(result[:result][:tools]).to contain_exactly(
-        include(name: "get_issue", description: "Retrieve a Linear issue by ID"),
+        include(name: "get_issue", description: "Retrieve a Linear issue by ID, including its parent and direct child issues"),
         include(name: "list_issues", description: "List issues with optional filters and pagination"),
         include(name: "list_issue_statuses", description: "List available issue statuses in a Linear team"),
         include(name: "list_teams", description: "List teams in the workspace"),

--- a/spec/linear_toon_mcp/tools/get_issue_spec.rb
+++ b/spec/linear_toon_mcp/tools/get_issue_spec.rb
@@ -41,6 +41,12 @@ RSpec.describe LinearToonMcp::Tools::GetIssue do
               "title" => "Sub-task A",
               "url" => "https://linear.app/test/issue/TEST-2",
               "state" => {"name" => "Done"}
+            },
+            {
+              "identifier" => "TEST-3",
+              "title" => "Sub-task B",
+              "url" => "https://linear.app/test/issue/TEST-3",
+              "state" => {"name" => "In Progress"}
             }
           ]
         }
@@ -63,16 +69,19 @@ RSpec.describe LinearToonMcp::Tools::GetIssue do
       expect(response.content.first[:text]).to include("Umbrella epic")
     end
 
-    it "includes child issues in the response" do
-      expect(response.content.first[:text]).to include("TEST-2")
-      expect(response.content.first[:text]).to include("Sub-task A")
+    it "includes all child issues in the response" do
+      text = response.content.first[:text]
+      expect(text).to include("TEST-2")
+      expect(text).to include("Sub-task A")
+      expect(text).to include("TEST-3")
+      expect(text).to include("Sub-task B")
     end
 
-    it "requests parent and children fields from Linear" do
+    it "requests parent and capped children fields from Linear" do
       response
       expect(client).to have_received(:query).with(
         a_string_matching(/parent \{ identifier title url state \{ name \} \}/)
-          .and(a_string_matching(/children \{ nodes \{ identifier title url state \{ name \} \} \}/)),
+          .and(a_string_matching(/children\(first: 50\) \{ nodes \{ identifier title url state \{ name \} \} \}/)),
         variables: {id: "TEST-1"}
       )
     end

--- a/spec/linear_toon_mcp/tools/get_issue_spec.rb
+++ b/spec/linear_toon_mcp/tools/get_issue_spec.rb
@@ -27,7 +27,23 @@ RSpec.describe LinearToonMcp::Tools::GetIssue do
         "labels" => {"nodes" => [{"name" => "bug"}]},
         "project" => {"id" => "proj-1", "name" => "My Project"},
         "team" => {"id" => "team-1", "name" => "Engineering"},
-        "attachments" => {"nodes" => []}
+        "attachments" => {"nodes" => []},
+        "parent" => {
+          "identifier" => "TEST-0",
+          "title" => "Umbrella epic",
+          "url" => "https://linear.app/test/issue/TEST-0",
+          "state" => {"name" => "In Progress"}
+        },
+        "children" => {
+          "nodes" => [
+            {
+              "identifier" => "TEST-2",
+              "title" => "Sub-task A",
+              "url" => "https://linear.app/test/issue/TEST-2",
+              "state" => {"name" => "Done"}
+            }
+          ]
+        }
       }
     end
 
@@ -42,12 +58,46 @@ RSpec.describe LinearToonMcp::Tools::GetIssue do
       expect(response.content.first[:text]).to include("Fix the bug")
     end
 
+    it "includes the parent issue in the response" do
+      expect(response.content.first[:text]).to include("TEST-0")
+      expect(response.content.first[:text]).to include("Umbrella epic")
+    end
+
+    it "includes child issues in the response" do
+      expect(response.content.first[:text]).to include("TEST-2")
+      expect(response.content.first[:text]).to include("Sub-task A")
+    end
+
+    it "requests parent and children fields from Linear" do
+      response
+      expect(client).to have_received(:query).with(
+        a_string_matching(/parent \{ identifier title url state \{ name \} \}/)
+          .and(a_string_matching(/children \{ nodes \{ identifier title url state \{ name \} \} \}/)),
+        variables: {id: "TEST-1"}
+      )
+    end
+
     it "queries Linear with the issue ID" do
       response
       expect(client).to have_received(:query).with(
         described_class::QUERY,
         variables: {id: "TEST-1"}
       )
+    end
+
+    context "when the issue has no parent and no children" do
+      let(:issue_data) do
+        super().merge(
+          "parent" => nil,
+          "children" => {"nodes" => []}
+        )
+      end
+
+      it "still returns a successful response" do
+        expect(response).to be_a(MCP::Tool::Response)
+        expect(response).not_to be_error
+        expect(response.content.first[:text]).to include("TEST-1")
+      end
     end
 
     context "when the issue does not exist" do


### PR DESCRIPTION
## Summary
- Adds `parent { identifier title url state { name } }` and `children { nodes { identifier title url state { name } } }` to the `get_issue` GraphQL projection so agents can traverse umbrella/sub-issue relationships without an extra roundtrip.
- README's `get_issue` row updated to mention the new fields.
- No version bump — batching with other in-flight changes for the next release.

Closes #34.

## Test plan
- [x] `bundle exec rspec spec/linear_toon_mcp/tools/get_issue_spec.rb` (9 examples, including new cases for populated parent/children and the null-parent/empty-children edge case)
- [x] `bundle exec rspec` full suite (197 examples, 0 failures)
- [x] `bundle exec standardrb` clean on changed files