### PR TITLE
#32 fix: scope label name resolution to target team

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ claude mcp add linear-toon -e LINEAR_API_KEY=lin_api_xxxxx -- linear-toon-mcp
 | `list_projects` | List projects, optionally scoped to a team. Returns project id, name, and state. |
 | `list_cycles` | List cycles for a team. Returns cycle id, name, number, startsAt, and endsAt. Requires team name or UUID. |
 | `get_project` | Retrieve a specific project by name, ID, or slug. Returns project details including state, priority, dates, progress, and lead. Optional includes for members, milestones, and resources. |
-| `create_issue` | Create a new Linear issue. Accepts human-friendly names for team, assignee, state, labels, project, cycle, and milestone (resolved to IDs automatically). Supports issue relations and link attachments. |
-| `update_issue` | Update an existing Linear issue by ID. Supports partial updates, null to remove fields, and relation replacement. |
+| `create_issue` | Create a new Linear issue. Accepts human-friendly names for team, assignee, state, labels, project, cycle, and milestone (resolved to IDs automatically; label names resolve against the target team or workspace-wide labels). Supports issue relations and link attachments. |
+| `update_issue` | Update an existing Linear issue by ID. Supports partial updates, null to remove fields, and relation replacement. Label names resolve against the issue's team or workspace-wide labels. |
 | `create_comment` | Create a comment on a Linear issue. Supports Markdown content and threaded replies via parentId. |
 | `list_comments` | List comments for a specific Linear issue in chronological order. Returns each comment's id, body, author, and timestamps. |
 

--- a/lib/linear_toon_mcp/resolvers.rb
+++ b/lib/linear_toon_mcp/resolvers.rb
@@ -92,21 +92,45 @@ module LinearToonMcp
       data.dig("workflowStates", "nodes", 0, "id") or raise Error, "State not found: #{value}"
     end
 
+    # Resolve a single label name or UUID to its UUID.
+    # When +team_id+ is supplied, restricts the lookup to labels scoped to that
+    # team or to workspace-wide labels (where the label's team relation is null),
+    # so a name like "Bug" matches the right team-scoped label and not a same-named
+    # label on another team.
     # @param client [Client]
     # @param value [String] label UUID or name
+    # @param team_id [String, nil] optional team UUID to scope the lookup
     # @return [String] label UUID
     # @raise [Error] when label not found
-    def resolve_label(client, value)
+    def resolve_label(client, value, team_id: nil)
       return value if value.match?(UUID_RE)
-      data = client.query(LABEL_QUERY, variables: {filter: {name: {eqIgnoreCase: value}}})
-      data.dig("issueLabels", "nodes", 0, "id") or raise Error, "Label not found: #{value}"
+
+      filter = {name: {eqIgnoreCase: value}}
+      if team_id
+        filter[:or] = [
+          {team: {null: true}},
+          {team: {id: {eq: team_id}}}
+        ]
+      end
+
+      data = client.query(LABEL_QUERY, variables: {filter:})
+      id = data.dig("issueLabels", "nodes", 0, "id")
+      return id if id
+
+      raise Error, label_not_found_message(value, team_id)
     end
 
     # @param client [Client]
     # @param values [Array<String>] label UUIDs or names
+    # @param team_id [String, nil] optional team UUID to scope the lookup
     # @return [Array<String>] label UUIDs
-    def resolve_labels(client, values)
-      values.map { |v| resolve_label(client, v) }
+    def resolve_labels(client, values, team_id: nil)
+      values.map { |v| resolve_label(client, v, team_id:) }
+    end
+
+    def label_not_found_message(value, team_id)
+      return "Label not found: #{value}" unless team_id
+      "Label not found on target team or workspace: #{value}"
     end
 
     # @param client [Client]

--- a/lib/linear_toon_mcp/tools/create_issue.rb
+++ b/lib/linear_toon_mcp/tools/create_issue.rb
@@ -131,7 +131,7 @@ module LinearToonMcp
           project: nil, cycle: nil, milestone: nil, delegate: nil, **)
           input[:assigneeId] = Resolvers.resolve_user(client, delegate || assignee) if assignee || delegate
           input[:stateId] = Resolvers.resolve_state(client, team_id, state) if state
-          input[:labelIds] = Resolvers.resolve_labels(client, labels) if labels
+          input[:labelIds] = Resolvers.resolve_labels(client, labels, team_id:) if labels
           project_id = Resolvers.resolve_project(client, project) if project
           input[:projectId] = project_id if project_id
           input[:cycleId] = Resolvers.resolve_cycle(client, team_id, cycle) if cycle

--- a/lib/linear_toon_mcp/tools/update_issue.rb
+++ b/lib/linear_toon_mcp/tools/update_issue.rb
@@ -179,7 +179,9 @@ module LinearToonMcp
         def add_resolved_fields(input, client, team_id, kwargs)
           input[:teamId] = team_id if kwargs.key?(:team) && team_id
           input[:stateId] = Resolvers.resolve_state(client, team_id, kwargs[:state]) if kwargs.key?(:state) && team_id
-          input[:labelIds] = Resolvers.resolve_labels(client, kwargs[:labels], team_id:) if kwargs.key?(:labels)
+          if kwargs.key?(:labels) && team_id
+            input[:labelIds] = Resolvers.resolve_labels(client, kwargs[:labels], team_id:)
+          end
           project_id = nil
           if kwargs.key?(:project) && kwargs[:project]
             project_id = Resolvers.resolve_project(client, kwargs[:project])

--- a/lib/linear_toon_mcp/tools/update_issue.rb
+++ b/lib/linear_toon_mcp/tools/update_issue.rb
@@ -150,7 +150,7 @@ module LinearToonMcp
         end
 
         def needs_team_id?(kwargs)
-          kwargs.key?(:state) || kwargs.key?(:cycle)
+          kwargs.key?(:state) || kwargs.key?(:cycle) || kwargs.key?(:labels)
         end
 
         def build_input(input, client, team_id, kwargs)
@@ -179,7 +179,7 @@ module LinearToonMcp
         def add_resolved_fields(input, client, team_id, kwargs)
           input[:teamId] = team_id if kwargs.key?(:team) && team_id
           input[:stateId] = Resolvers.resolve_state(client, team_id, kwargs[:state]) if kwargs.key?(:state) && team_id
-          input[:labelIds] = Resolvers.resolve_labels(client, kwargs[:labels]) if kwargs.key?(:labels)
+          input[:labelIds] = Resolvers.resolve_labels(client, kwargs[:labels], team_id:) if kwargs.key?(:labels)
           project_id = nil
           if kwargs.key?(:project) && kwargs[:project]
             project_id = Resolvers.resolve_project(client, kwargs[:project])

--- a/spec/linear_toon_mcp/resolvers_spec.rb
+++ b/spec/linear_toon_mcp/resolvers_spec.rb
@@ -67,18 +67,46 @@ RSpec.describe LinearToonMcp::Resolvers do
   end
 
   describe ".resolve_label" do
+    let(:team_id) { "team-uuid" }
+
     it "passes through UUIDs unchanged" do
       expect(described_class.resolve_label(client, uuid)).to eq(uuid)
     end
 
-    it "resolves a name to an ID" do
+    it "resolves a name to an ID with a plain name filter when no team given" do
       allow(client).to receive(:query).and_return("issueLabels" => {"nodes" => [{"id" => "label-uuid"}]})
       expect(described_class.resolve_label(client, "bug")).to eq("label-uuid")
+      expect(client).to have_received(:query).with(
+        anything,
+        variables: {filter: {name: {eqIgnoreCase: "bug"}}}
+      )
     end
 
-    it "raises when label not found" do
+    it "scopes the lookup to the team (and workspace labels) when team_id is given" do
+      allow(client).to receive(:query).and_return("issueLabels" => {"nodes" => [{"id" => "label-uuid"}]})
+      described_class.resolve_label(client, "bug", team_id: team_id)
+      expect(client).to have_received(:query).with(
+        anything,
+        variables: {filter: {
+          name: {eqIgnoreCase: "bug"},
+          or: [
+            {team: {null: true}},
+            {team: {id: {eq: team_id}}}
+          ]
+        }}
+      )
+    end
+
+    it "raises a team-aware error when label not found on team or workspace" do
       allow(client).to receive(:query).and_return("issueLabels" => {"nodes" => []})
-      expect { described_class.resolve_label(client, "Missing") }.to raise_error(LinearToonMcp::Error, /Label not found/)
+      expect { described_class.resolve_label(client, "Missing", team_id: team_id) }
+        .to raise_error(LinearToonMcp::Error, /Label not found on target team or workspace: Missing/)
+    end
+
+    it "raises a plain error when label not found without team scope" do
+      allow(client).to receive(:query).and_return("issueLabels" => {"nodes" => []})
+      expect { described_class.resolve_label(client, "Missing") }
+        .to raise_error(LinearToonMcp::Error, /\ALabel not found: Missing\z/)
     end
   end
 
@@ -92,6 +120,18 @@ RSpec.describe LinearToonMcp::Resolvers do
     it "passes through UUIDs without querying" do
       result = described_class.resolve_labels(client, [uuid])
       expect(result).to eq([uuid])
+    end
+
+    it "forwards team_id to each per-label lookup" do
+      allow(client).to receive(:query).and_return("issueLabels" => {"nodes" => [{"id" => "l1"}]})
+      described_class.resolve_labels(client, ["bug"], team_id: "team-uuid")
+      expect(client).to have_received(:query).with(
+        anything,
+        variables: hash_including(filter: hash_including(or: [
+          {team: {null: true}},
+          {team: {id: {eq: "team-uuid"}}}
+        ]))
+      )
     end
   end
 

--- a/spec/linear_toon_mcp/resolvers_spec.rb
+++ b/spec/linear_toon_mcp/resolvers_spec.rb
@@ -127,11 +127,28 @@ RSpec.describe LinearToonMcp::Resolvers do
       described_class.resolve_labels(client, ["bug"], team_id: "team-uuid")
       expect(client).to have_received(:query).with(
         anything,
-        variables: hash_including(filter: hash_including(or: [
-          {team: {null: true}},
-          {team: {id: {eq: "team-uuid"}}}
-        ]))
+        variables: {filter: {
+          name: {eqIgnoreCase: "bug"},
+          or: [
+            {team: {null: true}},
+            {team: {id: {eq: "team-uuid"}}}
+          ]
+        }}
       )
+    end
+
+    it "mixes UUIDs and names without re-querying the UUIDs" do
+      allow(client).to receive(:query).and_return("issueLabels" => {"nodes" => [{"id" => "name-resolved"}]})
+      result = described_class.resolve_labels(client, [uuid, "bug"], team_id: "team-uuid")
+      expect(result).to eq([uuid, "name-resolved"])
+      expect(client).to have_received(:query).once
+    end
+
+    it "returns an empty array without querying when given no labels" do
+      allow(client).to receive(:query)
+      result = described_class.resolve_labels(client, [], team_id: "team-uuid")
+      expect(result).to eq([])
+      expect(client).not_to have_received(:query)
     end
   end
 

--- a/spec/linear_toon_mcp/tools/create_issue_spec.rb
+++ b/spec/linear_toon_mcp/tools/create_issue_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe LinearToonMcp::Tools::CreateIssue do
         allow(LinearToonMcp::Resolvers).to receive(:resolve_team).with(client, "Engineering").and_return(team_id)
         allow(LinearToonMcp::Resolvers).to receive(:resolve_user).with(client, "Alice").and_return("user-uuid")
         allow(LinearToonMcp::Resolvers).to receive(:resolve_state).with(client, team_id, "In Progress").and_return("state-uuid")
-        allow(LinearToonMcp::Resolvers).to receive(:resolve_labels).with(client, ["bug", "urgent"]).and_return(["l1", "l2"])
+        allow(LinearToonMcp::Resolvers).to receive(:resolve_labels).with(client, ["bug", "urgent"], team_id: team_id).and_return(["l1", "l2"])
         allow(LinearToonMcp::Resolvers).to receive(:resolve_project).with(client, "My Project").and_return("proj-uuid")
         allow(LinearToonMcp::Resolvers).to receive(:resolve_cycle).with(client, team_id, "Sprint 5").and_return("cycle-uuid")
       end

--- a/spec/linear_toon_mcp/tools/update_issue_spec.rb
+++ b/spec/linear_toon_mcp/tools/update_issue_spec.rb
@@ -94,6 +94,25 @@ RSpec.describe LinearToonMcp::Tools::UpdateIssue do
       end
     end
 
+    context "with labels but no team" do
+      let(:params) { {id: issue_id, labels: ["Bug"]} }
+
+      before do
+        allow(client).to receive(:query).with(described_class::ISSUE_TEAM_QUERY, variables: {id: issue_id})
+          .and_return("issue" => {"team" => {"id" => "fetched-team-uuid"}})
+        allow(LinearToonMcp::Resolvers).to receive(:resolve_labels)
+          .with(client, ["Bug"], team_id: "fetched-team-uuid").and_return(["label-uuid"])
+        allow(client).to receive(:query).with(described_class::MUTATION, anything)
+          .and_return("issueUpdate" => {"success" => true, "issue" => issue_data})
+      end
+
+      it "fetches issue team and resolves labels scoped to it" do
+        response
+        expect(client).to have_received(:query).with(described_class::ISSUE_TEAM_QUERY, variables: {id: issue_id})
+        expect(LinearToonMcp::Resolvers).to have_received(:resolve_labels).with(client, ["Bug"], team_id: "fetched-team-uuid")
+      end
+    end
+
     context "with state but no team" do
       let(:params) { {id: issue_id, state: "Done"} }
 


### PR DESCRIPTION
## Summary
- Linear labels can be **workspace-wide** (`team: null`) or **team-scoped**. Two labels with the same name can coexist on different teams, so name-only lookups can resolve to the wrong team's label → Linear rejects with \`labelIds for incorrect team\`.
- \`Resolvers.resolve_label\` and \`.resolve_labels\` now take an optional \`team_id:\` kwarg. When supplied, the GraphQL filter restricts matches to that team OR workspace-wide labels using \`IssueLabelFilter\`'s documented \`or\` + \`NullableTeamFilter.null\` syntax (verified against Linear's published schema).
- \`create_issue\` already had the team UUID and now passes it through. \`update_issue\` extends \`needs_team_id?\` to include \`:labels\` so the issue's team is fetched first when labels are changed.
- Errors are team-aware: \`"Label not found on target team or workspace: API"\` instead of the opaque GraphQL error.
- Resolver callers without a \`team_id\` keep the legacy plain-name lookup (backwards-compatible).
- No version bump — batched with other in-flight changes for the next release.

Closes #32.

## Test plan
- [x] \`bundle exec rspec spec/linear_toon_mcp/resolvers_spec.rb\` — new cases for team-scoped filter shape, workspace fallback, team-aware error, legacy path
- [x] \`bundle exec rspec spec/linear_toon_mcp/tools/update_issue_spec.rb\` — new \"labels but no team\" context proves the issue's team is fetched
- [x] \`bundle exec rspec\` full suite (197 examples, 0 failures)
- [x] \`bundle exec standardrb\` clean