### PR TITLE
#45 refactor: unify tools with CRUD verb hierarchy + module-level client

### DIFF
--- a/lib/linear_toon_mcp.rb
+++ b/lib/linear_toon_mcp.rb
@@ -13,13 +13,13 @@ module LinearToonMcp
   class Error < StandardError; end
 
   class << self
-    # Returns the active Linear API client. Lazily instantiated from
-    # +LINEAR_API_KEY+ on first access. Assignable via {.client=} for
-    # injection (tests, custom configuration).
+    # Returns the active Linear API client, lazily instantiated from
+    # +LINEAR_API_KEY+ on first access.
     def client
       @client ||= Client.new
     end
 
+    # Assigns the active Linear API client.
     attr_writer :client
   end
 

--- a/lib/linear_toon_mcp.rb
+++ b/lib/linear_toon_mcp.rb
@@ -4,19 +4,7 @@ require "mcp"
 require_relative "linear_toon_mcp/version"
 require_relative "linear_toon_mcp/client"
 require_relative "linear_toon_mcp/resolvers"
-require_relative "linear_toon_mcp/tools/get_issue"
-require_relative "linear_toon_mcp/tools/list_issues"
-require_relative "linear_toon_mcp/tools/create_comment"
-require_relative "linear_toon_mcp/tools/list_comments"
-require_relative "linear_toon_mcp/tools/create_issue"
-require_relative "linear_toon_mcp/tools/update_issue"
-require_relative "linear_toon_mcp/tools/list_issue_statuses"
-require_relative "linear_toon_mcp/tools/list_teams"
-require_relative "linear_toon_mcp/tools/list_users"
-require_relative "linear_toon_mcp/tools/list_issue_labels"
-require_relative "linear_toon_mcp/tools/list_projects"
-require_relative "linear_toon_mcp/tools/list_cycles"
-require_relative "linear_toon_mcp/tools/get_project"
+require_relative "linear_toon_mcp/tools"
 
 # Token-efficient MCP server for Linear. Wraps Linear's GraphQL API
 # and returns TOON-formatted responses for ~40-60% token savings.
@@ -24,16 +12,25 @@ module LinearToonMcp
   # Raised on Linear API HTTP errors, GraphQL errors, or missing data.
   class Error < StandardError; end
 
-  # Build a configured MCP::Server with all registered tools.
-  # @param client [Client] Linear API client (defaults to new instance from ENV)
+  class << self
+    # Returns the active Linear API client. Lazily instantiated from
+    # +LINEAR_API_KEY+ on first access. Assignable via {.client=} for
+    # injection (tests, custom configuration).
+    def client
+      @client ||= Client.new
+    end
+
+    attr_writer :client
+  end
+
+  # Builds the configured MCP::Server with all registered tools.
   # @return [MCP::Server]
-  def self.server(client: Client.new)
+  def self.server
     MCP::Server.new(
       name: "linear-toon-mcp",
       version: VERSION,
       description: "Manage Linear issues, projects, and teams",
-      tools: [Tools::GetIssue, Tools::ListIssues, Tools::ListIssueStatuses, Tools::ListTeams, Tools::ListUsers, Tools::ListIssueLabels, Tools::ListProjects, Tools::ListCycles, Tools::GetProject, Tools::CreateComment, Tools::ListComments, Tools::CreateIssue, Tools::UpdateIssue],
-      server_context: {client:}
+      tools: [Tools::GetIssue, Tools::ListIssues, Tools::ListIssueStatuses, Tools::ListTeams, Tools::ListUsers, Tools::ListIssueLabels, Tools::ListProjects, Tools::ListCycles, Tools::GetProject, Tools::CreateComment, Tools::ListComments, Tools::CreateIssue, Tools::UpdateIssue]
     )
   end
 end

--- a/lib/linear_toon_mcp/resolvers.rb
+++ b/lib/linear_toon_mcp/resolvers.rb
@@ -2,12 +2,13 @@
 
 module LinearToonMcp
   # Resolvers translate human-friendly identifiers — UUIDs, names, emails,
-  # slugs, numbers, the literal "me" — into Linear API UUIDs.
+  # slugs, numbers, the literal "me" — into Linear API UUIDs. They read
+  # {LinearToonMcp.client} for API calls.
   #
   # @example
-  #   Resolvers::Team.call(client, "Engineering")
-  #   Resolvers::WorkflowState.call(client, "In Progress", team_id: tid)
-  #   Resolvers::IssueLabel.call_many(client, ["bug", "p1"], team_id: tid)
+  #   Resolvers::Team.call(value: "Engineering")
+  #   Resolvers::WorkflowState.call(value: "In Progress", team_id: tid)
+  #   Resolvers::IssueLabel.call_many(values: ["bug", "p1"], team_id: tid)
   module Resolvers
     UUID_RE = /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
     NUMERIC_RE = /\A\d+\z/

--- a/lib/linear_toon_mcp/resolvers/base.rb
+++ b/lib/linear_toon_mcp/resolvers/base.rb
@@ -132,32 +132,30 @@ module LinearToonMcp
           GRAPHQL
         end
 
-        # Resolves +value+ to a UUID.
+        # Resolves +value+ to a UUID using {LinearToonMcp.client}.
         #
-        #   Team.call(client, value: "Engineering")
-        #   WorkflowState.call(client, value: "Done", team_id: tid)
+        #   Team.call(value: "Engineering")
+        #   WorkflowState.call(value: "Done", team_id: tid)
         #
-        # @param client [Client]
         # @param value [String]
         # @param scope [Hash] parent-scope kwargs (e.g. +team_id:+)
         # @return [String] resolved UUID
         # @raise [Error] when no attribute resolves the value
-        def call(client, value:, **scope)
-          new(client, **scope).resolve(value)
+        def call(value:, **scope)
+          new(**scope).resolve(value)
         end
 
         # Resolves each value via {.call}, forwarding scope.
         #
-        #   IssueLabel.call_many(client, values: ["bug", "p1"], team_id: tid)
+        #   IssueLabel.call_many(values: ["bug", "p1"], team_id: tid)
         #
         # @return [Array<String>]
-        def call_many(client, values:, **scope)
-          values.map { |v| call(client, value: v, **scope) }
+        def call_many(values:, **scope)
+          values.map { |v| call(value: v, **scope) }
         end
       end
 
-      def initialize(client, **scope)
-        @client = client
+      def initialize(**scope)
         @scope = scope
       end
 
@@ -182,7 +180,11 @@ module LinearToonMcp
 
       private
 
-      attr_reader :client, :scope
+      attr_reader :scope
+
+      def client
+        LinearToonMcp.client
+      end
 
       def scope_filter
         cfg = self.class.scope_config

--- a/lib/linear_toon_mcp/tools.rb
+++ b/lib/linear_toon_mcp/tools.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module LinearToonMcp
+  # MCP tool classes. Each tool inherits a CRUD verb base
+  # ({Tools::List}, {Tools::Get}, {Tools::Create}, {Tools::Update},
+  # {Tools::Delete}) which inherits {Tools::Base} for the shared
+  # envelope.
+  module Tools
+  end
+end
+
+require_relative "tools/base"
+require_relative "tools/list"
+require_relative "tools/get"
+require_relative "tools/create"
+require_relative "tools/update"
+require_relative "tools/get_issue"
+require_relative "tools/list_issues"
+require_relative "tools/create_comment"
+require_relative "tools/list_comments"
+require_relative "tools/create_issue"
+require_relative "tools/update_issue"
+require_relative "tools/list_issue_statuses"
+require_relative "tools/list_teams"
+require_relative "tools/list_users"
+require_relative "tools/list_issue_labels"
+require_relative "tools/list_projects"
+require_relative "tools/list_cycles"
+require_relative "tools/get_project"

--- a/lib/linear_toon_mcp/tools/base.rb
+++ b/lib/linear_toon_mcp/tools/base.rb
@@ -4,25 +4,20 @@ require "toon"
 
 module LinearToonMcp
   module Tools
-    # Base class for MCP tools. Subclasses implement {#perform} and
-    # inherit the standard envelope: TOON-encoded responses and a single
-    # +rescue LinearToonMcp::Error+ at the boundary. The Linear client is
-    # read from {LinearToonMcp.client}.
+    # Base class for all MCP tools. Subclasses implement {#perform};
+    # responses are TOON-encoded and {LinearToonMcp::Error} is caught at
+    # the boundary. The Linear client is read from {LinearToonMcp.client}.
     #
     #   class ListTeams < Tools::List
     #     description "..."
     #     input_schema(...)
     #     QUERY = "..."
     #   end
-    #
-    # Verb subclasses ({Tools::List}, {Tools::Get}, {Tools::Create},
-    # {Tools::Update}, {Tools::Delete}) layer the CRUD-specific shape on
-    # top — connection extraction, mutation success checks, and so on.
     class Base < MCP::Tool
       class << self
         # Entry point invoked by the MCP server. Instantiates the tool
-        # and dispatches to its {#perform}. {LinearToonMcp::Error}s
-        # raised anywhere along the path become error responses.
+        # and dispatches to its {#perform}. Any {LinearToonMcp::Error}
+        # raised along the way becomes an error response.
         #
         # @return [MCP::Tool::Response]
         def call(server_context: nil, **params)
@@ -31,22 +26,23 @@ module LinearToonMcp
           error_response(e.message)
         end
 
-        # Wraps +data+ in a successful MCP response with TOON-encoded text.
+        # Returns a successful MCP response with TOON-encoded +data+.
+        # @return [MCP::Tool::Response]
         def success_response(data)
           MCP::Tool::Response.new([{type: "text", text: Toon.encode(data)}])
         end
 
-        # Wraps +message+ in an error MCP response.
+        # Returns an error MCP response carrying +message+.
+        # @return [MCP::Tool::Response]
         def error_response(message)
           MCP::Tool::Response.new([{type: "text", text: message}], error: true)
         end
       end
 
       # Runs the tool with validated parameters and returns the MCP
-      # response. Subclasses normally override {#perform}, not this method.
+      # response. Subclasses override {#perform}, not this method.
       # When {#perform} returns an {MCP::Tool::Response}, it is passed
-      # through unchanged — letting subclasses craft the response directly
-      # (e.g., to append post-mutation warnings).
+      # through unchanged.
       def call(**params)
         result = perform(**params)
         result.is_a?(MCP::Tool::Response) ? result : self.class.success_response(result)
@@ -62,15 +58,14 @@ module LinearToonMcp
 
       private
 
-      # The active Linear API client.
       def client
         LinearToonMcp.client
       end
 
       # Returns an {MCP::Tool::Response} with TOON-encoded +data+ followed
       # by a +WARNING (<context>): ...+ line when +warnings+ is non-empty.
-      # Used by mutating tools whose post-mutation steps may fail
-      # partially (issue created, but link attach failed).
+      #
+      # @return [MCP::Tool::Response]
       def respond_with_warnings(data, warnings, context:)
         text = Toon.encode(data)
         text += "\nWARNING (#{context}): #{warnings.join("; ")}" if warnings.any?

--- a/lib/linear_toon_mcp/tools/base.rb
+++ b/lib/linear_toon_mcp/tools/base.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "toon"
+
+module LinearToonMcp
+  module Tools
+    # Base class for MCP tools. Subclasses implement {#perform} and
+    # inherit the standard envelope: TOON-encoded responses and a single
+    # +rescue LinearToonMcp::Error+ at the boundary. The Linear client is
+    # read from {LinearToonMcp.client}.
+    #
+    #   class ListTeams < Tools::List
+    #     description "..."
+    #     input_schema(...)
+    #     QUERY = "..."
+    #   end
+    #
+    # Verb subclasses ({Tools::List}, {Tools::Get}, {Tools::Create},
+    # {Tools::Update}, {Tools::Delete}) layer the CRUD-specific shape on
+    # top — connection extraction, mutation success checks, and so on.
+    class Base < MCP::Tool
+      class << self
+        # Entry point invoked by the MCP server. Instantiates the tool
+        # and dispatches to its {#perform}. {LinearToonMcp::Error}s
+        # raised anywhere along the path become error responses.
+        #
+        # @return [MCP::Tool::Response]
+        def call(server_context: nil, **params)
+          new.call(**params)
+        rescue Error => e
+          error_response(e.message)
+        end
+
+        # Wraps +data+ in a successful MCP response with TOON-encoded text.
+        def success_response(data)
+          MCP::Tool::Response.new([{type: "text", text: Toon.encode(data)}])
+        end
+
+        # Wraps +message+ in an error MCP response.
+        def error_response(message)
+          MCP::Tool::Response.new([{type: "text", text: message}], error: true)
+        end
+      end
+
+      # Runs the tool with validated parameters and returns the MCP
+      # response. Subclasses normally override {#perform}, not this method.
+      # When {#perform} returns an {MCP::Tool::Response}, it is passed
+      # through unchanged — letting subclasses craft the response directly
+      # (e.g., to append post-mutation warnings).
+      def call(**params)
+        result = perform(**params)
+        result.is_a?(MCP::Tool::Response) ? result : self.class.success_response(result)
+      rescue Error => e
+        self.class.error_response(e.message)
+      end
+
+      # Subclass hook. Returns the Ruby value to TOON-encode, or a
+      # pre-built {MCP::Tool::Response}.
+      def perform(**)
+        raise NotImplementedError, "#{self.class.name} must implement #perform"
+      end
+
+      private
+
+      # The active Linear API client.
+      def client
+        LinearToonMcp.client
+      end
+
+      # Returns an {MCP::Tool::Response} with TOON-encoded +data+ followed
+      # by a +WARNING (<context>): ...+ line when +warnings+ is non-empty.
+      # Used by mutating tools whose post-mutation steps may fail
+      # partially (issue created, but link attach failed).
+      def respond_with_warnings(data, warnings, context:)
+        text = Toon.encode(data)
+        text += "\nWARNING (#{context}): #{warnings.join("; ")}" if warnings.any?
+        MCP::Tool::Response.new([{type: "text", text:}])
+      end
+    end
+  end
+end

--- a/lib/linear_toon_mcp/tools/create.rb
+++ b/lib/linear_toon_mcp/tools/create.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module LinearToonMcp
+  module Tools
+    # Base class for create-mutation tools. Submits the +MUTATION+
+    # constant, asserts the +success+ flag, and returns the created
+    # entity. The mutation field and entity key derive from the class
+    # name:
+    #
+    #   CreateIssue.mutation_name    # => "issueCreate"
+    #   CreateIssue.entity_name      # => "issue"
+    #   CreateComment.mutation_name  # => "commentCreate"
+    #
+    # Subclasses define the +MUTATION+ constant and override {#variables}
+    # to construct the GraphQL input.
+    class Create < Base
+      class << self
+        # Returns the GraphQL mutation field name.
+        def mutation_name
+          @mutation_name ||= "#{entity_name}Create"
+        end
+
+        # Returns the entity field name inside the mutation payload.
+        def entity_name
+          @entity_name ||= derive_entity_name
+        end
+
+        # Returns the entity label for error messages.
+        #
+        #   CreateIssue.entity_label  # => "Issue"
+        def entity_label
+          @entity_label ||= name.split("::").last.sub(/\ACreate/, "")
+        end
+
+        # Returns the GraphQL mutation — the +MUTATION+ constant on the
+        # subclass.
+        def mutation_string
+          const_get(:MUTATION)
+        end
+
+        private
+
+        def derive_entity_name
+          entity = name.split("::").last.sub(/\ACreate/, "")
+          entity[0].downcase + entity[1..]
+        end
+      end
+
+      # Submits {.mutation_string} with {#variables}, validates the
+      # +success+ flag, and returns the created entity.
+      #
+      # @raise [Error] when the mutation fails
+      def perform(**params)
+        data = client.query(self.class.mutation_string, variables: variables(**params))
+        result = data[self.class.mutation_name] or raise Error, "#{self.class.entity_label} creation failed: no result returned"
+        raise Error, "#{self.class.entity_label} creation failed" unless result["success"]
+
+        result[self.class.entity_name]
+      end
+
+      # Subclass hook. Returns the GraphQL variables hash for the
+      # mutation. Subclasses must implement.
+      def variables(**)
+        raise NotImplementedError, "#{self.class.name} must implement #variables"
+      end
+    end
+  end
+end

--- a/lib/linear_toon_mcp/tools/create_comment.rb
+++ b/lib/linear_toon_mcp/tools/create_comment.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
-require "toon"
-
 module LinearToonMcp
   module Tools
     # Create a comment on a Linear issue. Supports Markdown content
     # and threaded replies via parentId.
-    class CreateComment < MCP::Tool
+    class CreateComment < Create
       description "Create a comment on a Linear issue"
 
       annotations(
@@ -41,27 +39,10 @@ module LinearToonMcp
       GRAPHQL
 
       # standard:disable Naming/VariableName
-      class << self
-        # @param issueId [String] Linear issue ID
-        # @param body [String] comment content as Markdown
-        # @param parentId [String, nil] parent comment ID for threaded replies
-        # @param server_context [Hash, nil] must contain +:client+ key with a {Client}
-        # @return [MCP::Tool::Response] TOON-encoded comment or error
-        def call(issueId:, body:, parentId: nil, server_context: nil)
-          client = server_context&.dig(:client) or raise Error, "client missing from server_context"
-
-          input = {issueId:, body:}
-          input[:parentId] = parentId if parentId
-
-          data = client.query(MUTATION, variables: {input:})
-          result = data["commentCreate"]
-          raise Error, "Comment creation failed" unless result["success"]
-
-          text = Toon.encode(result["comment"])
-          MCP::Tool::Response.new([{type: "text", text:}])
-        rescue Error => e
-          MCP::Tool::Response.new([{type: "text", text: e.message}], error: true)
-        end
+      def variables(issueId:, body:, parentId: nil)
+        input = {issueId:, body:}
+        input[:parentId] = parentId if parentId
+        {input:}
       end
       # standard:enable Naming/VariableName
     end

--- a/lib/linear_toon_mcp/tools/create_issue.rb
+++ b/lib/linear_toon_mcp/tools/create_issue.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "toon"
-
 module LinearToonMcp
   module Tools
     # Create a new Linear issue with full parameter support.
@@ -10,7 +8,7 @@ module LinearToonMcp
     # duplicateOf) and parentId accept either issue UUIDs or human identifiers
     # (e.g., LIN-123); both are passed through to Linear unchanged.
     # Supports post-mutation relations and links.
-    class CreateIssue < MCP::Tool
+    class CreateIssue < Create
       description "Create a new Linear issue"
 
       annotations(
@@ -75,96 +73,81 @@ module LinearToonMcp
       GRAPHQL
 
       # standard:disable Naming/VariableName, Metrics/MethodLength
-      class << self
-        # @param title [String] issue title
-        # @param team [String] team name or UUID
-        # @param server_context [Hash, nil] must contain +:client+ key
-        # @return [MCP::Tool::Response] TOON-encoded issue or error
-        def call(title:, team:, server_context: nil, **kwargs)
-          client = server_context&.dig(:client) or raise Error, "client missing from server_context"
-          raise Error, "Cannot specify both assignee and delegate" if kwargs.key?(:assignee) && kwargs.key?(:delegate)
+      def perform(**kwargs)
+        raise Error, "Cannot specify both assignee and delegate" if kwargs.key?(:assignee) && kwargs.key?(:delegate)
+        issue = super
+        warnings = post_create(issue["id"], **kwargs)
+        warnings.empty? ? issue : respond_with_warnings(issue, warnings, context: "issue was created")
+      end
 
-          team_id = Resolvers::Team.call(client, value: team)
-          input = {title:, teamId: team_id}
+      def variables(title:, team:, **kwargs)
+        team_id = Resolvers::Team.call(value: team)
+        input = {title:, teamId: team_id}
+        add_direct_fields(input, **kwargs)
+        resolve_fields(input, team_id, **kwargs)
+        {input:}
+      end
 
-          add_direct_fields(input, **kwargs)
-          resolve_fields(input, client, team_id, **kwargs)
+      private
 
-          data = client.query(MUTATION, variables: {input:})
-          result = data["issueCreate"] or raise Error, "Issue creation failed: no result returned"
-          raise Error, "Issue creation failed" unless result["success"]
-
-          issue = result["issue"]
-          warnings = post_create(client, issue["id"], **kwargs)
-
-          text = Toon.encode(issue)
-          text += "\nWARNING (issue was created): #{warnings.join("; ")}" if warnings.any?
-          MCP::Tool::Response.new([{type: "text", text:}])
+      def post_create(issue_id, links: nil, **kwargs)
+        warnings = []
+        begin
+          create_relations(issue_id, **kwargs)
         rescue Error => e
-          MCP::Tool::Response.new([{type: "text", text: e.message}], error: true)
+          warnings << e.message
         end
-
-        private
-
-        def post_create(client, issue_id, links: nil, **kwargs)
-          warnings = []
-          begin
-            create_relations(client, issue_id, **kwargs)
-          rescue Error => e
-            warnings << e.message
-          end
-          begin
-            create_links(client, issue_id, links)
-          rescue Error => e
-            warnings << e.message
-          end
-          warnings
+        begin
+          create_links(issue_id, links)
+        rescue Error => e
+          warnings << e.message
         end
+        warnings
+      end
 
-        def add_direct_fields(input, description: nil, priority: nil, estimate: nil,
-          dueDate: nil, parentId: nil, **)
-          input[:description] = description if description
-          input[:priority] = priority if priority
-          input[:estimate] = estimate if estimate
-          input[:dueDate] = dueDate if dueDate
-          input[:parentId] = parentId if parentId
+      def add_direct_fields(input, description: nil, priority: nil, estimate: nil,
+        dueDate: nil, parentId: nil, **)
+        input[:description] = description if description
+        input[:priority] = priority if priority
+        input[:estimate] = estimate if estimate
+        input[:dueDate] = dueDate if dueDate
+        input[:parentId] = parentId if parentId
+      end
+
+      def resolve_fields(input, team_id, assignee: nil, state: nil, labels: nil,
+        project: nil, cycle: nil, milestone: nil, delegate: nil, **)
+        input[:assigneeId] = Resolvers::User.call(value: delegate || assignee) if assignee || delegate
+        input[:stateId] = Resolvers::WorkflowState.call(value: state, team_id:) if state
+        input[:labelIds] = Resolvers::IssueLabel.call_many(values: labels, team_id:) if labels
+        project_id = Resolvers::Project.call(value: project) if project
+        input[:projectId] = project_id if project_id
+        input[:cycleId] = Resolvers::Cycle.call(value: cycle, team_id:) if cycle
+        if milestone
+          raise Error, "milestone requires project" unless project_id
+          input[:projectMilestoneId] = Resolvers::ProjectMilestone.call(value: milestone, project_id:)
         end
+      end
 
-        def resolve_fields(input, client, team_id, assignee: nil, state: nil, labels: nil,
-          project: nil, cycle: nil, milestone: nil, delegate: nil, **)
-          input[:assigneeId] = Resolvers::User.call(client, value: delegate || assignee) if assignee || delegate
-          input[:stateId] = Resolvers::WorkflowState.call(client, value: state, team_id:) if state
-          input[:labelIds] = Resolvers::IssueLabel.call_many(client, values: labels, team_id:) if labels
-          project_id = Resolvers::Project.call(client, value: project) if project
-          input[:projectId] = project_id if project_id
-          input[:cycleId] = Resolvers::Cycle.call(client, value: cycle, team_id:) if cycle
-          if milestone
-            raise Error, "milestone requires project" unless project_id
-            input[:projectMilestoneId] = Resolvers::ProjectMilestone.call(client, value: milestone, project_id:)
-          end
-        end
+      def create_relations(issue_id, blocks: nil, relatedTo: nil, duplicateOf: nil, **)
+        Array(blocks).each { |id| create_relation(issue_id, id, "blocks") }
+        Array(relatedTo).each { |id| create_relation(issue_id, id, "related") }
+        create_relation(issue_id, duplicateOf, "duplicate") if duplicateOf
+      end
 
-        def create_relations(client, issue_id, blocks: nil, relatedTo: nil, duplicateOf: nil, **)
-          Array(blocks).each { |id| create_relation(client, issue_id, id, "blocks") }
-          Array(relatedTo).each { |id| create_relation(client, issue_id, id, "related") }
-          create_relation(client, issue_id, duplicateOf, "duplicate") if duplicateOf
-        end
+      def create_relation(issue_id, related_issue_id, type)
+        input = {issueId: issue_id, relatedIssueId: related_issue_id, type:}
+        data = client.query(RELATION_MUTATION, variables: {input:})
+        return if data.dig("issueRelationCreate", "success")
+        raise Error, "Failed to create #{type} relation with #{related_issue_id}"
+      end
 
-        def create_relation(client, issue_id, related_issue_id, type)
-          input = {issueId: issue_id, relatedIssueId: related_issue_id, type:}
-          data = client.query(RELATION_MUTATION, variables: {input:})
-          return if data.dig("issueRelationCreate", "success")
-          raise Error, "Failed to create #{type} relation with #{related_issue_id}"
-        end
+      def create_links(issue_id, links)
+        return unless links
 
-        def create_links(client, issue_id, links)
-          return unless links
-
-          links.each do |link|
-            data = client.query(LINK_MUTATION, variables: {url: link[:url], issueId: issue_id, title: link[:title]})
-            next if data.dig("attachmentLinkURL", "success")
-            raise Error, "Failed to attach link: #{link[:url]}"
-          end
+        links.each do |link|
+          data = client.query(LINK_MUTATION, variables: {url: link[:url], issueId: issue_id, title: link[:title]})
+          next if data.dig("attachmentLinkURL", "success")
+          raise Error, "Failed to attach link: #{link[:url]}"
         end
       end
       # standard:enable Naming/VariableName, Metrics/MethodLength

--- a/lib/linear_toon_mcp/tools/get.rb
+++ b/lib/linear_toon_mcp/tools/get.rb
@@ -10,8 +10,8 @@ module LinearToonMcp
     #   GetIssue.entity_name    # => "issue"
     #   GetProject.entity_name  # => "project"
     #
-    # Subclasses define the +QUERY+ constant and optionally override
-    # {#variables} when the lookup key needs resolving.
+    # Subclasses define the +QUERY+ constant and override {#variables}
+    # when the lookup key needs resolving first (e.g., name/slug → UUID).
     class Get < Base
       class << self
         # Overrides the derived GraphQL entity field name.

--- a/lib/linear_toon_mcp/tools/get.rb
+++ b/lib/linear_toon_mcp/tools/get.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module LinearToonMcp
+  module Tools
+    # Base class for single-entity read tools. Queries by id and
+    # extracts the named entity field; raises a labeled not-found error
+    # when the field is +nil+. The entity field name derives from the
+    # class name:
+    #
+    #   GetIssue.entity_name    # => "issue"
+    #   GetProject.entity_name  # => "project"
+    #
+    # Subclasses define the +QUERY+ constant and optionally override
+    # {#variables} when the lookup key needs resolving.
+    class Get < Base
+      class << self
+        # Overrides the derived GraphQL entity field name.
+        def entity(name)
+          @entity = name.to_s
+        end
+
+        # Returns the GraphQL entity field name.
+        def entity_name
+          @entity ||= derive_entity_name
+        end
+
+        # Returns the entity label for not-found messages.
+        #
+        #   GetIssue.entity_label  # => "Issue"
+        def entity_label
+          @entity_label ||= name.split("::").last.sub(/\AGet/, "")
+        end
+
+        # Returns the GraphQL query — the +QUERY+ constant on the subclass.
+        def query_string
+          const_get(:QUERY)
+        end
+
+        private
+
+        def derive_entity_name
+          entity = name.split("::").last.sub(/\AGet/, "")
+          entity[0].downcase + entity[1..]
+        end
+      end
+
+      # Queries {.query_string} with {#variables} and extracts the
+      # entity field.
+      #
+      # @raise [Error] when the entity is not found
+      def perform(**params)
+        data = client.query(self.class.query_string, variables: variables(**params))
+        data[self.class.entity_name] or raise Error, not_found_message(**params)
+      end
+
+      # Subclass hook. Returns the GraphQL variables hash for {#perform}.
+      # Defaults to +{id: id}+; override when the lookup key needs
+      # resolving first (e.g., name/slug → UUID).
+      def variables(id:, **)
+        {id: id}
+      end
+
+      # Subclass hook. Returns the not-found error message.
+      def not_found_message(id: nil, **)
+        "#{self.class.entity_label} not found: #{id}"
+      end
+    end
+  end
+end

--- a/lib/linear_toon_mcp/tools/get_issue.rb
+++ b/lib/linear_toon_mcp/tools/get_issue.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
-require "toon"
-
 module LinearToonMcp
   module Tools
     # Fetch a single Linear issue by ID or identifier and return it as TOON.
     # Includes metadata, state, assignee, labels, project, team, attachments,
     # parent issue, and direct child issues.
-    class GetIssue < MCP::Tool
+    class GetIssue < Get
       description "Retrieve a Linear issue by ID, including its parent and direct child issues"
 
       annotations(
@@ -52,21 +50,6 @@ module LinearToonMcp
           }
         }
       GRAPHQL
-
-      class << self
-        # @param id [String] Linear issue ID or identifier (e.g., "LIN-123")
-        # @param server_context [Hash, nil] must contain +:client+ key with a {Client}
-        # @return [MCP::Tool::Response] TOON-encoded issue or error
-        def call(id:, server_context: nil)
-          client = server_context&.dig(:client) or raise Error, "client missing from server_context"
-          data = client.query(QUERY, variables: {id:})
-          issue = data["issue"] or raise Error, "Issue not found: #{id}"
-          text = Toon.encode(issue)
-          MCP::Tool::Response.new([{type: "text", text:}])
-        rescue Error => e
-          MCP::Tool::Response.new([{type: "text", text: e.message}], error: true)
-        end
-      end
     end
   end
 end

--- a/lib/linear_toon_mcp/tools/get_project.rb
+++ b/lib/linear_toon_mcp/tools/get_project.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
-require "toon"
-
 module LinearToonMcp
   module Tools
     # Fetch a single Linear project by ID, name, or slug and return it as TOON.
     # Supports optional includes for members, milestones, and resources.
-    class GetProject < MCP::Tool
+    class GetProject < Get
       description "Retrieve details of a specific project in Linear"
 
       annotations(
@@ -57,41 +55,29 @@ module LinearToonMcp
       RESOURCES_FIELDS = "documents { nodes { id title } }"
 
       # standard:disable Naming/VariableName
-      class << self
-        # @param query [String] Project ID, name, or slug
-        # @param includeMembers [Boolean] Include project members
-        # @param includeMilestones [Boolean] Include project milestones
-        # @param includeResources [Boolean] Include documents
-        # @param server_context [Hash, nil] must contain +:client+ key with a {Client}
-        # @return [MCP::Tool::Response] TOON-encoded project or error
-        def call(query:, includeMembers: false, includeMilestones: false, includeResources: false, server_context: nil)
-          client = server_context&.dig(:client) or raise Error, "client missing from server_context"
-          project_id = Resolvers::Project.call(client, value: query)
-          graphql = build_query(includeMembers:, includeMilestones:, includeResources:)
-          data = client.query(graphql, variables: {id: project_id})
-          project = data["project"] or raise Error, "Project not found: #{query}"
-          text = Toon.encode(project)
-          MCP::Tool::Response.new([{type: "text", text:}])
-        rescue Error => e
-          MCP::Tool::Response.new([{type: "text", text: e.message}], error: true)
-        end
+      # @param query [String] project name, ID, or slug
+      def perform(query:, includeMembers: false, includeMilestones: false, includeResources: false)
+        project_id = Resolvers::Project.call(value: query)
+        graphql = build_query(includeMembers:, includeMilestones:, includeResources:)
+        data = client.query(graphql, variables: {id: project_id})
+        data["project"] or raise Error, "Project not found: #{query}"
+      end
 
-        private
+      private
 
-        def build_query(includeMembers:, includeMilestones:, includeResources:)
-          fields = [BASE_FIELDS.strip]
-          fields << MEMBERS_FIELDS if includeMembers
-          fields << MILESTONES_FIELDS if includeMilestones
-          fields << RESOURCES_FIELDS if includeResources
+      def build_query(includeMembers:, includeMilestones:, includeResources:)
+        fields = [BASE_FIELDS.strip]
+        fields << MEMBERS_FIELDS if includeMembers
+        fields << MILESTONES_FIELDS if includeMilestones
+        fields << RESOURCES_FIELDS if includeResources
 
-          <<~GRAPHQL
-            query($id: String!) {
-              project(id: $id) {
-                #{fields.join("\n        ")}
-              }
+        <<~GRAPHQL
+          query($id: String!) {
+            project(id: $id) {
+              #{fields.join("\n        ")}
             }
-          GRAPHQL
-        end
+          }
+        GRAPHQL
       end
       # standard:enable Naming/VariableName
     end

--- a/lib/linear_toon_mcp/tools/list.rb
+++ b/lib/linear_toon_mcp/tools/list.rb
@@ -9,14 +9,11 @@ module LinearToonMcp
     #   ListTeams.connection_name        # => "teams"
     #   ListIssueLabels.connection_name  # => "issueLabels"
     #
-    # Override with {.connection} when the GraphQL field diverges:
+    # Override with {.connection} when the GraphQL field diverges
+    # (e.g., +ListIssueStatuses+ → +workflowStates+).
     #
-    #   class ListIssueStatuses < Tools::List
-    #     connection :workflowStates
-    #   end
-    #
-    # Subclasses define the +QUERY+ constant and optionally override
-    # {#variables} to compute GraphQL variables from inputs.
+    # Subclasses define the +QUERY+ constant and override {#variables}
+    # to compute GraphQL variables from inputs.
     class List < Base
       class << self
         # Overrides the derived GraphQL connection name.

--- a/lib/linear_toon_mcp/tools/list.rb
+++ b/lib/linear_toon_mcp/tools/list.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module LinearToonMcp
+  module Tools
+    # Base class for list tools. Queries a top-level GraphQL connection
+    # and returns its +nodes+ + +pageInfo+. The connection name derives
+    # from the class name:
+    #
+    #   ListTeams.connection_name        # => "teams"
+    #   ListIssueLabels.connection_name  # => "issueLabels"
+    #
+    # Override with {.connection} when the GraphQL field diverges:
+    #
+    #   class ListIssueStatuses < Tools::List
+    #     connection :workflowStates
+    #   end
+    #
+    # Subclasses define the +QUERY+ constant and optionally override
+    # {#variables} to compute GraphQL variables from inputs.
+    class List < Base
+      class << self
+        # Overrides the derived GraphQL connection name.
+        def connection(name)
+          @connection = name.to_s
+        end
+
+        # Returns the GraphQL connection field name.
+        def connection_name
+          @connection ||= derive_connection_name
+        end
+
+        # Returns the GraphQL query — the +QUERY+ constant on the subclass.
+        def query_string
+          const_get(:QUERY)
+        end
+
+        private
+
+        def derive_connection_name
+          entity = name.split("::").last.sub(/\AList/, "")
+          entity[0].downcase + entity[1..]
+        end
+      end
+
+      # Queries {.query_string} with {#variables} and extracts the
+      # connection field.
+      #
+      # @raise [Error] when the connection field is missing
+      def perform(**params)
+        data = client.query(self.class.query_string, variables: variables(**params))
+        data[self.class.connection_name] or raise Error, "Unexpected response: missing #{self.class.connection_name} field"
+      end
+
+      # Subclass hook. Returns the GraphQL variables hash for {#perform}.
+      # Defaults to no variables.
+      def variables(**)
+        {}
+      end
+    end
+  end
+end

--- a/lib/linear_toon_mcp/tools/list_comments.rb
+++ b/lib/linear_toon_mcp/tools/list_comments.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
-require "toon"
-
 module LinearToonMcp
   module Tools
     # List comments on a Linear issue in chronological order.
     # Returns each comment's author, body, and timestamps.
-    class ListComments < MCP::Tool
+    class ListComments < List
       description "List comments for a specific Linear issue"
 
       annotations(
@@ -44,19 +42,11 @@ module LinearToonMcp
       GRAPHQL
 
       # standard:disable Naming/VariableName
-      class << self
-        # @param issueId [String] Linear issue ID or identifier (e.g., "LIN-123")
-        # @param server_context [Hash, nil] must contain +:client+ key with a {Client}
-        # @return [MCP::Tool::Response] TOON-encoded comments connection or error
-        def call(issueId:, server_context: nil)
-          client = server_context&.dig(:client) or raise Error, "client missing from server_context"
-          data = client.query(QUERY, variables: {id: issueId})
-          issue = data["issue"] or raise Error, "Issue not found: #{issueId}"
-          text = Toon.encode(issue["comments"])
-          MCP::Tool::Response.new([{type: "text", text:}])
-        rescue Error => e
-          MCP::Tool::Response.new([{type: "text", text: e.message}], error: true)
-        end
+      # @param issueId [String] Linear issue ID or identifier (e.g., "LIN-123")
+      def perform(issueId:)
+        data = client.query(QUERY, variables: {id: issueId})
+        issue = data["issue"] or raise Error, "Issue not found: #{issueId}"
+        issue["comments"]
       end
       # standard:enable Naming/VariableName
     end

--- a/lib/linear_toon_mcp/tools/list_cycles.rb
+++ b/lib/linear_toon_mcp/tools/list_cycles.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
-require "toon"
-
 module LinearToonMcp
   module Tools
     # List cycles for a Linear team.
     # Returns TOON-encoded array of cycles with id, name, number, startsAt, and endsAt.
-    class ListCycles < MCP::Tool
+    class ListCycles < List
       description "List cycles for a team"
 
       annotations(
@@ -29,20 +27,10 @@ module LinearToonMcp
         }
       GRAPHQL
 
-      class << self
-        # @param team [String] team name or UUID
-        # @param server_context [Hash, nil] must contain +:client+ key with a {Client}
-        # @return [MCP::Tool::Response] TOON-encoded cycle list or error
-        def call(team:, server_context: nil)
-          client = server_context&.dig(:client) or raise Error, "client missing from server_context"
-          team_id = Resolvers::Team.call(client, value: team)
-          data = client.query(QUERY, variables: {filter: {team: {id: {eq: team_id}}}})
-          cycles = data["cycles"] or raise Error, "Unexpected response: missing cycles field"
-          text = Toon.encode(cycles)
-          MCP::Tool::Response.new([{type: "text", text:}])
-        rescue Error => e
-          MCP::Tool::Response.new([{type: "text", text: e.message}], error: true)
-        end
+      # @param team [String] team name or UUID
+      def variables(team:)
+        team_id = Resolvers::Team.call(value: team)
+        {filter: {team: {id: {eq: team_id}}}}
       end
     end
   end

--- a/lib/linear_toon_mcp/tools/list_issue_labels.rb
+++ b/lib/linear_toon_mcp/tools/list_issue_labels.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
-require "toon"
-
 module LinearToonMcp
   module Tools
     # List issue labels in the Linear workspace, optionally scoped to a team.
     # Returns TOON-encoded array of labels with id and name.
-    class ListIssueLabels < MCP::Tool
+    class ListIssueLabels < List
       description "List issue labels, optionally scoped to a team"
 
       annotations(
@@ -28,26 +26,11 @@ module LinearToonMcp
         }
       GRAPHQL
 
-      class << self
-        # @param team [String, nil] team name or UUID (optional scope)
-        # @param server_context [Hash, nil] must contain +:client+ key with a {Client}
-        # @return [MCP::Tool::Response] TOON-encoded label list or error
-        def call(team: nil, server_context: nil)
-          client = server_context&.dig(:client) or raise Error, "client missing from server_context"
-
-          variables = {}
-          if team
-            team_id = Resolvers::Team.call(client, value: team)
-            variables[:filter] = {team: {id: {eq: team_id}}}
-          end
-
-          data = client.query(QUERY, variables:)
-          labels = data["issueLabels"] or raise Error, "Unexpected response: missing issueLabels field"
-          text = Toon.encode(labels)
-          MCP::Tool::Response.new([{type: "text", text:}])
-        rescue Error => e
-          MCP::Tool::Response.new([{type: "text", text: e.message}], error: true)
-        end
+      # @param team [String, nil] team name or UUID (optional scope)
+      def variables(team: nil)
+        return {} unless team
+        team_id = Resolvers::Team.call(value: team)
+        {filter: {team: {id: {eq: team_id}}}}
       end
     end
   end

--- a/lib/linear_toon_mcp/tools/list_issue_statuses.rb
+++ b/lib/linear_toon_mcp/tools/list_issue_statuses.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
-require "toon"
-
 module LinearToonMcp
   module Tools
     # List available workflow states for a Linear team.
     # Returns TOON-encoded array of statuses with id, type, and name.
-    class ListIssueStatuses < MCP::Tool
+    class ListIssueStatuses < List
       description "List available issue statuses in a Linear team"
 
       annotations(
@@ -23,26 +21,18 @@ module LinearToonMcp
         additionalProperties: false
       )
 
+      connection :workflowStates
+
       QUERY = <<~GRAPHQL
         query($filter: WorkflowStateFilter) {
           workflowStates(filter: $filter) { nodes { id type name } }
         }
       GRAPHQL
 
-      class << self
-        # @param team [String] team name or UUID
-        # @param server_context [Hash, nil] must contain +:client+ key with a {Client}
-        # @return [MCP::Tool::Response] TOON-encoded status list or error
-        def call(team:, server_context: nil)
-          client = server_context&.dig(:client) or raise Error, "client missing from server_context"
-          team_id = Resolvers::Team.call(client, value: team)
-          data = client.query(QUERY, variables: {filter: {team: {id: {eq: team_id}}}})
-          states = data["workflowStates"] or raise Error, "Unexpected response: missing workflowStates field"
-          text = Toon.encode(states)
-          MCP::Tool::Response.new([{type: "text", text:}])
-        rescue Error => e
-          MCP::Tool::Response.new([{type: "text", text: e.message}], error: true)
-        end
+      # @param team [String] team name or UUID
+      def variables(team:)
+        team_id = Resolvers::Team.call(value: team)
+        {filter: {team: {id: {eq: team_id}}}}
       end
     end
   end

--- a/lib/linear_toon_mcp/tools/list_issues.rb
+++ b/lib/linear_toon_mcp/tools/list_issues.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
-require "toon"
-
 module LinearToonMcp
   module Tools
     # List Linear issues with optional filters and pagination.
     # Returns TOON-encoded array with page info for cursor-based pagination.
-    class ListIssues < MCP::Tool
+    class ListIssues < List
       description "List issues with optional filters and pagination"
 
       annotations(
@@ -67,104 +65,78 @@ module LinearToonMcp
       NUMERIC_RE = Resolvers::NUMERIC_RE
 
       # standard:disable Naming/VariableName
-      class << self
-        # @param assignee [String, nil] user ID, name, email, or "me"
-        # @param createdAt [String, nil] ISO-8601 date or duration
-        # @param cursor [String, nil] pagination cursor
-        # @param cycle [String, nil] cycle name, number, or ID
-        # @param delegate [String, nil] agent name or ID
-        # @param includeArchived [Boolean, nil] include archived issues
-        # @param label [String, nil] label name or ID
-        # @param limit [Integer, nil] max results (default 50, max 250)
-        # @param orderBy [String, nil] "createdAt" or "updatedAt"
-        # @param parentId [String, nil] parent issue ID
-        # @param priority [Integer, nil] 0-4
-        # @param project [String, nil] project name or ID
-        # @param query [String, nil] search title or description
-        # @param state [String, nil] state name or ID
-        # @param team [String, nil] team name or ID
-        # @param updatedAt [String, nil] ISO-8601 date or duration
-        # @param server_context [Hash, nil] must contain +:client+ key with a {Client}
-        # @return [MCP::Tool::Response] TOON-encoded issue list or error
-        def call(assignee: nil, createdAt: nil, cursor: nil, cycle: nil,
-          delegate: nil, includeArchived: nil, label: nil, limit: nil, orderBy: nil,
-          parentId: nil, priority: nil, project: nil, query: nil, state: nil,
-          team: nil, updatedAt: nil, server_context: nil)
-          client = server_context&.dig(:client) or raise Error, "client missing from server_context"
-
-          filter = build_filter(
-            assignee:, team:, project:, state:, label:,
-            priority:, parentId:, cycle:, delegate:,
-            query:, createdAt:, updatedAt:
-          )
-
-          variables = {
-            first: (limit || 50).clamp(1, 250),
-            orderBy: orderBy || "updatedAt",
-            includeArchived: includeArchived != false
-          }
-          variables[:filter] = filter unless filter.empty?
-          variables[:after] = cursor if cursor
-
-          data = client.query(QUERY, variables:)
-          issues = data["issues"] or raise Error, "Unexpected response: missing issues field"
-          text = Toon.encode(issues)
-          MCP::Tool::Response.new([{type: "text", text:}])
-        rescue Error => e
-          MCP::Tool::Response.new([{type: "text", text: e.message}], error: true)
-        end
-
-        private
-
-        def build_filter(assignee:, team:, project:, state:, label:,
+      def perform(assignee: nil, createdAt: nil, cursor: nil, cycle: nil,
+        delegate: nil, includeArchived: nil, label: nil, limit: nil, orderBy: nil,
+        parentId: nil, priority: nil, project: nil, query: nil, state: nil,
+        team: nil, updatedAt: nil)
+        filter = build_filter(
+          assignee:, team:, project:, state:, label:,
           priority:, parentId:, cycle:, delegate:,
-          query:, createdAt:, updatedAt:)
-          filter = {}
-          filter[:assignee] = assignee_filter(assignee) if assignee
-          filter[:team] = name_or_id(team) if team
-          filter[:project] = name_or_id(project) if project
-          filter[:state] = name_or_id(state) if state
-          filter[:labels] = {some: name_or_id(label)} if label
-          filter[:priority] = {eq: priority} if priority
-          filter[:parent] = {id: {eq: parentId}} if parentId
-          filter[:cycle] = cycle_filter(cycle) if cycle
-          filter[:delegate] = name_or_id(delegate) if delegate
-          if query
-            filter[:or] = [
-              {title: {containsIgnoreCase: query}},
-              {description: {containsIgnoreCase: query}}
-            ]
-          end
-          filter[:createdAt] = {gte: resolve_date(createdAt)} if createdAt
-          filter[:updatedAt] = {gte: resolve_date(updatedAt)} if updatedAt
-          filter
-        end
-        # standard:enable Naming/VariableName
+          query:, createdAt:, updatedAt:
+        )
 
-        def assignee_filter(value)
-          return {isMe: {eq: true}} if value == "me"
-          return {id: {eq: value}} if value.match?(UUID_RE)
-          return {email: {eq: value}} if value.include?("@")
-          {name: {eqIgnoreCase: value}}
-        end
+        variables = {
+          first: (limit || 50).clamp(1, 250),
+          orderBy: orderBy || "updatedAt",
+          includeArchived: includeArchived != false
+        }
+        variables[:filter] = filter unless filter.empty?
+        variables[:after] = cursor if cursor
 
-        def name_or_id(value)
-          value.match?(UUID_RE) ? {id: {eq: value}} : {name: {eqIgnoreCase: value}}
-        end
+        data = client.query(self.class::QUERY, variables: variables)
+        data["issues"] or raise Error, "Unexpected response: missing issues field"
+      end
 
-        def cycle_filter(value)
-          return {id: {eq: value}} if value.match?(UUID_RE)
-          return {number: {eq: value.to_i}} if value.match?(NUMERIC_RE)
-          {name: {eqIgnoreCase: value}}
-        end
+      private
 
-        def resolve_date(value)
-          return value unless value.start_with?("-P")
-          match = value.match(/\A-P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?\z/)
-          raise Error, "Invalid duration: #{value}" unless match
-          days = match.captures.zip([365, 30, 7, 1]).sum { |c, m| (c&.to_i || 0) * m }
-          (Time.now.utc - (days * 86_400)).iso8601
+      def build_filter(assignee:, team:, project:, state:, label:,
+        priority:, parentId:, cycle:, delegate:,
+        query:, createdAt:, updatedAt:)
+        filter = {}
+        filter[:assignee] = assignee_filter(assignee) if assignee
+        filter[:team] = name_or_id(team) if team
+        filter[:project] = name_or_id(project) if project
+        filter[:state] = name_or_id(state) if state
+        filter[:labels] = {some: name_or_id(label)} if label
+        filter[:priority] = {eq: priority} if priority
+        filter[:parent] = {id: {eq: parentId}} if parentId
+        filter[:cycle] = cycle_filter(cycle) if cycle
+        filter[:delegate] = name_or_id(delegate) if delegate
+        if query
+          filter[:or] = [
+            {title: {containsIgnoreCase: query}},
+            {description: {containsIgnoreCase: query}}
+          ]
         end
+        filter[:createdAt] = {gte: resolve_date(createdAt)} if createdAt
+        filter[:updatedAt] = {gte: resolve_date(updatedAt)} if updatedAt
+        filter
+      end
+      # standard:enable Naming/VariableName
+
+      def assignee_filter(value)
+        return {isMe: {eq: true}} if value == "me"
+        return {id: {eq: value}} if value.match?(UUID_RE)
+        return {email: {eq: value}} if value.include?("@")
+        {name: {eqIgnoreCase: value}}
+      end
+
+      def name_or_id(value)
+        value.match?(UUID_RE) ? {id: {eq: value}} : {name: {eqIgnoreCase: value}}
+      end
+
+      def cycle_filter(value)
+        return {id: {eq: value}} if value.match?(UUID_RE)
+        return {number: {eq: value.to_i}} if value.match?(NUMERIC_RE)
+        {name: {eqIgnoreCase: value}}
+      end
+
+      def resolve_date(value)
+        return value unless value.start_with?("-P")
+        match = value.match(/\A-P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?\z/)
+        raise Error, "Invalid duration: #{value}" unless match
+        days = match.captures.zip([365, 30, 7, 1]).sum { |c, m| (c&.to_i || 0) * m }
+        (Time.now.utc - (days * 86_400)).iso8601
       end
     end
   end

--- a/lib/linear_toon_mcp/tools/list_issues.rb
+++ b/lib/linear_toon_mcp/tools/list_issues.rb
@@ -83,7 +83,7 @@ module LinearToonMcp
         variables[:filter] = filter unless filter.empty?
         variables[:after] = cursor if cursor
 
-        data = client.query(self.class::QUERY, variables: variables)
+        data = client.query(self.class.query_string, variables: variables)
         data["issues"] or raise Error, "Unexpected response: missing issues field"
       end
 

--- a/lib/linear_toon_mcp/tools/list_projects.rb
+++ b/lib/linear_toon_mcp/tools/list_projects.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
-require "toon"
-
 module LinearToonMcp
   module Tools
     # List projects in the Linear workspace, optionally scoped to a team.
     # Returns TOON-encoded array of projects with id, name, and state.
-    class ListProjects < MCP::Tool
+    class ListProjects < List
       description "List projects, optionally scoped to a team"
 
       annotations(
@@ -28,26 +26,11 @@ module LinearToonMcp
         }
       GRAPHQL
 
-      class << self
-        # @param team [String, nil] team name or UUID (optional scope)
-        # @param server_context [Hash, nil] must contain +:client+ key with a {Client}
-        # @return [MCP::Tool::Response] TOON-encoded project list or error
-        def call(team: nil, server_context: nil)
-          client = server_context&.dig(:client) or raise Error, "client missing from server_context"
-
-          variables = {}
-          if team
-            team_id = Resolvers::Team.call(client, value: team)
-            variables[:filter] = {accessibleTeams: {id: {eq: team_id}}}
-          end
-
-          data = client.query(QUERY, variables:)
-          projects = data["projects"] or raise Error, "Unexpected response: missing projects field"
-          text = Toon.encode(projects)
-          MCP::Tool::Response.new([{type: "text", text:}])
-        rescue Error => e
-          MCP::Tool::Response.new([{type: "text", text: e.message}], error: true)
-        end
+      # @param team [String, nil] team name or UUID (optional scope)
+      def variables(team: nil)
+        return {} unless team
+        team_id = Resolvers::Team.call(value: team)
+        {filter: {accessibleTeams: {id: {eq: team_id}}}}
       end
     end
   end

--- a/lib/linear_toon_mcp/tools/list_teams.rb
+++ b/lib/linear_toon_mcp/tools/list_teams.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
-require "toon"
-
 module LinearToonMcp
   module Tools
     # List all teams in the Linear workspace.
     # Returns TOON-encoded array of teams with id, name, and key.
-    class ListTeams < MCP::Tool
+    class ListTeams < List
       description "List teams in the workspace"
 
       annotations(
@@ -25,20 +23,6 @@ module LinearToonMcp
           teams { nodes { id name key } }
         }
       GRAPHQL
-
-      class << self
-        # @param server_context [Hash, nil] must contain +:client+ key with a {Client}
-        # @return [MCP::Tool::Response] TOON-encoded team list or error
-        def call(server_context: nil)
-          client = server_context&.dig(:client) or raise Error, "client missing from server_context"
-          data = client.query(QUERY)
-          teams = data["teams"] or raise Error, "Unexpected response: missing teams field"
-          text = Toon.encode(teams)
-          MCP::Tool::Response.new([{type: "text", text:}])
-        rescue Error => e
-          MCP::Tool::Response.new([{type: "text", text: e.message}], error: true)
-        end
-      end
     end
   end
 end

--- a/lib/linear_toon_mcp/tools/list_users.rb
+++ b/lib/linear_toon_mcp/tools/list_users.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
-require "toon"
-
 module LinearToonMcp
   module Tools
     # List users in the Linear workspace, optionally scoped to a team.
     # Returns TOON-encoded array of users with id, name, and email.
-    class ListUsers < MCP::Tool
+    class ListUsers < List
       description "List users, optionally scoped to a team"
 
       annotations(
@@ -34,27 +32,12 @@ module LinearToonMcp
         }
       GRAPHQL
 
-      class << self
-        # @param team [String, nil] team name or UUID (optional scope)
-        # @param server_context [Hash, nil] must contain +:client+ key with a {Client}
-        # @return [MCP::Tool::Response] TOON-encoded user list or error
-        def call(team: nil, server_context: nil)
-          client = server_context&.dig(:client) or raise Error, "client missing from server_context"
-
-          users = if team
-            team_id = Resolvers::Team.call(client, value: team)
-            data = client.query(TEAM_MEMBERS_QUERY, variables: {id: team_id})
-            data.dig("team", "members") or raise Error, "Unexpected response: missing team members field"
-          else
-            data = client.query(QUERY)
-            data["users"] or raise Error, "Unexpected response: missing users field"
-          end
-
-          text = Toon.encode(users)
-          MCP::Tool::Response.new([{type: "text", text:}])
-        rescue Error => e
-          MCP::Tool::Response.new([{type: "text", text: e.message}], error: true)
-        end
+      # @param team [String, nil] team name or UUID (optional scope)
+      def perform(team: nil)
+        return super if team.nil?
+        team_id = Resolvers::Team.call(value: team)
+        data = client.query(TEAM_MEMBERS_QUERY, variables: {id: team_id})
+        data.dig("team", "members") or raise Error, "Unexpected response: missing team members field"
       end
     end
   end

--- a/lib/linear_toon_mcp/tools/update.rb
+++ b/lib/linear_toon_mcp/tools/update.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module LinearToonMcp
+  module Tools
+    # Base class for update-mutation tools. Submits the +MUTATION+
+    # constant, asserts the +success+ flag, and returns the updated
+    # entity. The mutation field and entity key derive from the class
+    # name:
+    #
+    #   UpdateIssue.mutation_name  # => "issueUpdate"
+    #   UpdateIssue.entity_name    # => "issue"
+    #
+    # Subclasses define the +MUTATION+ constant and override {#variables}
+    # to construct the GraphQL +id+ + +input+ payload.
+    class Update < Base
+      class << self
+        # Returns the GraphQL mutation field name.
+        def mutation_name
+          @mutation_name ||= "#{entity_name}Update"
+        end
+
+        # Returns the entity field name inside the mutation payload.
+        def entity_name
+          @entity_name ||= derive_entity_name
+        end
+
+        # Returns the entity label for error messages.
+        #
+        #   UpdateIssue.entity_label  # => "Issue"
+        def entity_label
+          @entity_label ||= name.split("::").last.sub(/\AUpdate/, "")
+        end
+
+        # Returns the GraphQL mutation — the +MUTATION+ constant on the
+        # subclass.
+        def mutation_string
+          const_get(:MUTATION)
+        end
+
+        private
+
+        def derive_entity_name
+          entity = name.split("::").last.sub(/\AUpdate/, "")
+          entity[0].downcase + entity[1..]
+        end
+      end
+
+      # Submits {.mutation_string} with {#variables}, validates the
+      # +success+ flag, and returns the updated entity.
+      #
+      # @raise [Error] when the mutation fails
+      def perform(**params)
+        data = client.query(self.class.mutation_string, variables: variables(**params))
+        result = data[self.class.mutation_name] or raise Error, "#{self.class.entity_label} update failed: no result returned"
+        raise Error, "#{self.class.entity_label} update failed" unless result["success"]
+
+        result[self.class.entity_name]
+      end
+
+      # Subclass hook. Returns the GraphQL +{id:, input:}+ hash for
+      # the mutation. Subclasses must implement.
+      def variables(**)
+        raise NotImplementedError, "#{self.class.name} must implement #variables"
+      end
+    end
+  end
+end

--- a/lib/linear_toon_mcp/tools/update_issue.rb
+++ b/lib/linear_toon_mcp/tools/update_issue.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "toon"
-
 module LinearToonMcp
   module Tools
     # Update an existing Linear issue by ID. Supports partial updates,
@@ -9,7 +7,7 @@ module LinearToonMcp
     # params (blocks, relatedTo, duplicateOf) and parentId accept either
     # issue UUIDs or human identifiers (e.g., LIN-123); both are passed
     # through to Linear unchanged.
-    class UpdateIssue < MCP::Tool
+    class UpdateIssue < Update
       description "Update an existing Linear issue"
 
       annotations(
@@ -101,145 +99,132 @@ module LinearToonMcp
       }.freeze
 
       # standard:disable Naming/VariableName, Metrics/MethodLength
-      class << self
-        # @param id [String] issue ID
-        # @param server_context [Hash, nil] must contain +:client+ key
-        # @return [MCP::Tool::Response] TOON-encoded issue or error
-        def call(id:, server_context: nil, **kwargs)
-          client = server_context&.dig(:client) or raise Error, "client missing from server_context"
-          raise Error, "Cannot specify both assignee and delegate" if kwargs.key?(:assignee) && kwargs.key?(:delegate)
+      def perform(id:, **kwargs)
+        raise Error, "Cannot specify both assignee and delegate" if kwargs.key?(:assignee) && kwargs.key?(:delegate)
+        issue = super
+        warnings = post_update(id, **kwargs)
+        warnings.empty? ? issue : respond_with_warnings(issue, warnings, context: "issue was updated")
+      end
 
-          input = {}
-          team_id = resolve_team_id(client, id, kwargs)
-          build_input(input, client, team_id, kwargs)
+      def variables(id:, **kwargs)
+        input = {}
+        team_id = resolve_team_id(id, kwargs)
+        build_input(input, team_id, kwargs)
+        {id:, input:}
+      end
 
-          data = client.query(MUTATION, variables: {id:, input:})
-          result = data["issueUpdate"] or raise Error, "Issue update failed: no result returned"
-          raise Error, "Issue update failed" unless result["success"]
+      private
 
-          issue = result["issue"]
-          warnings = post_update(client, id, **kwargs)
-
-          text = Toon.encode(issue)
-          text += "\nWARNING (issue was updated): #{warnings.join("; ")}" if warnings.any?
-          MCP::Tool::Response.new([{type: "text", text:}])
+      def post_update(issue_id, links: nil, **kwargs)
+        warnings = []
+        begin
+          replace_relations(issue_id, kwargs)
         rescue Error => e
-          MCP::Tool::Response.new([{type: "text", text: e.message}], error: true)
+          warnings << e.message
         end
-
-        private
-
-        def post_update(client, issue_id, links: nil, **kwargs)
-          warnings = []
-          begin
-            replace_relations(client, issue_id, kwargs)
-          rescue Error => e
-            warnings << e.message
-          end
-          begin
-            create_links(client, issue_id, links)
-          rescue Error => e
-            warnings << e.message
-          end
-          warnings
+        begin
+          create_links(issue_id, links)
+        rescue Error => e
+          warnings << e.message
         end
+        warnings
+      end
 
-        def resolve_team_id(client, issue_id, kwargs)
-          return Resolvers::Team.call(client, value: kwargs[:team]) if kwargs.key?(:team)
-          return unless needs_team_id?(kwargs)
+      def resolve_team_id(issue_id, kwargs)
+        return Resolvers::Team.call(value: kwargs[:team]) if kwargs.key?(:team)
+        return unless needs_team_id?(kwargs)
 
-          data = client.query(ISSUE_TEAM_QUERY, variables: {id: issue_id})
-          data.dig("issue", "team", "id") or raise Error, "Could not determine issue team"
+        data = client.query(ISSUE_TEAM_QUERY, variables: {id: issue_id})
+        data.dig("issue", "team", "id") or raise Error, "Could not determine issue team"
+      end
+
+      def needs_team_id?(kwargs)
+        kwargs.key?(:state) || kwargs.key?(:cycle) || kwargs.key?(:labels)
+      end
+
+      def build_input(input, team_id, kwargs)
+        add_direct_fields(input, kwargs)
+        add_nullable_fields(input, kwargs)
+        add_resolved_fields(input, team_id, kwargs)
+      end
+
+      def add_direct_fields(input, kwargs)
+        {title: :title, description: :description, priority: :priority,
+         estimate: :estimate, dueDate: :dueDate}.each do |key, field|
+          input[field] = kwargs[key] if kwargs.key?(key)
         end
+      end
 
-        def needs_team_id?(kwargs)
-          kwargs.key?(:state) || kwargs.key?(:cycle) || kwargs.key?(:labels)
+      def add_nullable_fields(input, kwargs)
+        if kwargs.key?(:assignee)
+          input[:assigneeId] =
+            kwargs[:assignee] ? Resolvers::User.call(value: kwargs[:assignee]) : nil
         end
-
-        def build_input(input, client, team_id, kwargs)
-          add_direct_fields(input, kwargs)
-          add_nullable_fields(input, client, kwargs)
-          add_resolved_fields(input, client, team_id, kwargs)
+        if kwargs.key?(:delegate)
+          input[:assigneeId] =
+            kwargs[:delegate] ? Resolvers::User.call(value: kwargs[:delegate]) : nil
         end
+        input[:parentId] = kwargs[:parentId] if kwargs.key?(:parentId)
+      end
 
-        def add_direct_fields(input, kwargs)
-          {title: :title, description: :description, priority: :priority,
-           estimate: :estimate, dueDate: :dueDate}.each do |key, field|
-            input[field] = kwargs[key] if kwargs.key?(key)
-          end
+      def add_resolved_fields(input, team_id, kwargs)
+        input[:teamId] = team_id if kwargs.key?(:team) && team_id
+        if kwargs.key?(:state) && team_id
+          input[:stateId] =
+            Resolvers::WorkflowState.call(value: kwargs[:state], team_id:)
         end
-
-        def add_nullable_fields(input, client, kwargs)
-          if kwargs.key?(:assignee)
-            input[:assigneeId] =
-              kwargs[:assignee] ? Resolvers::User.call(client, value: kwargs[:assignee]) : nil
-          end
-          if kwargs.key?(:delegate)
-            input[:assigneeId] =
-              kwargs[:delegate] ? Resolvers::User.call(client, value: kwargs[:delegate]) : nil
-          end
-          input[:parentId] = kwargs[:parentId] if kwargs.key?(:parentId)
+        if kwargs.key?(:labels) && team_id
+          input[:labelIds] = Resolvers::IssueLabel.call_many(values: kwargs[:labels], team_id:)
         end
-
-        def add_resolved_fields(input, client, team_id, kwargs)
-          input[:teamId] = team_id if kwargs.key?(:team) && team_id
-          if kwargs.key?(:state) && team_id
-            input[:stateId] =
-              Resolvers::WorkflowState.call(client, value: kwargs[:state], team_id:)
-          end
-          if kwargs.key?(:labels) && team_id
-            input[:labelIds] = Resolvers::IssueLabel.call_many(client, values: kwargs[:labels], team_id:)
-          end
-          project_id = nil
-          if kwargs.key?(:project) && kwargs[:project]
-            project_id = Resolvers::Project.call(client, value: kwargs[:project])
-            input[:projectId] = project_id
-          end
-          if kwargs.key?(:milestone)
-            raise Error, "milestone requires project" unless project_id
-            input[:projectMilestoneId] =
-              Resolvers::ProjectMilestone.call(client, value: kwargs[:milestone], project_id:)
-          end
-          if kwargs.key?(:cycle) && team_id
-            input[:cycleId] =
-              Resolvers::Cycle.call(client, value: kwargs[:cycle], team_id:)
-          end
+        project_id = nil
+        if kwargs.key?(:project) && kwargs[:project]
+          project_id = Resolvers::Project.call(value: kwargs[:project])
+          input[:projectId] = project_id
         end
+        if kwargs.key?(:milestone)
+          raise Error, "milestone requires project" unless project_id
+          input[:projectMilestoneId] =
+            Resolvers::ProjectMilestone.call(value: kwargs[:milestone], project_id:)
+        end
+        if kwargs.key?(:cycle) && team_id
+          input[:cycleId] =
+            Resolvers::Cycle.call(value: kwargs[:cycle], team_id:)
+        end
+      end
 
-        def replace_relations(client, issue_id, kwargs)
-          RELATION_TYPE_MAP.each do |param, type|
-            next unless kwargs.key?(param)
-            values = (param == :duplicateOf) ? [kwargs[param]].compact : Array(kwargs[param])
-            delete_existing_relations(client, issue_id, type)
-            values.each do |related_id|
-              input = {issueId: issue_id, relatedIssueId: related_id, type:}
-              data = client.query(RELATION_MUTATION, variables: {input:})
-              next if data.dig("issueRelationCreate", "success")
-              raise Error, "Failed to create #{type} relation with #{related_id}"
-            end
+      def replace_relations(issue_id, kwargs)
+        RELATION_TYPE_MAP.each do |param, type|
+          next unless kwargs.key?(param)
+          values = (param == :duplicateOf) ? [kwargs[param]].compact : Array(kwargs[param])
+          delete_existing_relations(issue_id, type)
+          values.each do |related_id|
+            input = {issueId: issue_id, relatedIssueId: related_id, type:}
+            data = client.query(RELATION_MUTATION, variables: {input:})
+            next if data.dig("issueRelationCreate", "success")
+            raise Error, "Failed to create #{type} relation with #{related_id}"
           end
         end
+      end
 
-        def delete_existing_relations(client, issue_id, type)
-          data = client.query(RELATIONS_QUERY, variables: {id: issue_id})
-          relations = data.dig("issue", "relations", "nodes") || []
-          relations.each do |rel|
-            next unless rel["type"] == type
-            del = client.query(RELATION_DELETE_MUTATION, variables: {id: rel["id"]})
-            next if del.dig("issueRelationDelete", "success")
-            raise Error, "Failed to delete #{type} relation #{rel["id"]}"
-          end
+      def delete_existing_relations(issue_id, type)
+        data = client.query(RELATIONS_QUERY, variables: {id: issue_id})
+        relations = data.dig("issue", "relations", "nodes") || []
+        relations.each do |rel|
+          next unless rel["type"] == type
+          del = client.query(RELATION_DELETE_MUTATION, variables: {id: rel["id"]})
+          next if del.dig("issueRelationDelete", "success")
+          raise Error, "Failed to delete #{type} relation #{rel["id"]}"
         end
+      end
 
-        def create_links(client, issue_id, links)
-          return unless links
+      def create_links(issue_id, links)
+        return unless links
 
-          links.each do |link|
-            vars = {url: link[:url], issueId: issue_id, title: link[:title]}
-            data = client.query(LINK_MUTATION, variables: vars)
-            next if data.dig("attachmentLinkURL", "success")
-            raise Error, "Failed to attach link: #{link[:url]}"
-          end
+        links.each do |link|
+          vars = {url: link[:url], issueId: issue_id, title: link[:title]}
+          data = client.query(LINK_MUTATION, variables: vars)
+          next if data.dig("attachmentLinkURL", "success")
+          raise Error, "Failed to attach link: #{link[:url]}"
         end
       end
       # standard:enable Naming/VariableName, Metrics/MethodLength

--- a/spec/linear_toon_mcp/resolvers/base_spec.rb
+++ b/spec/linear_toon_mcp/resolvers/base_spec.rb
@@ -33,8 +33,9 @@ RSpec.describe LinearToonMcp::Resolvers::Base do
         label "Thing"
         lookup_by :name
       end
+      LinearToonMcp.client = client
       allow(client).to receive(:query).and_return("things" => {"nodes" => []})
-      expect { resolver.call(client, value: "Missing") }
+      expect { resolver.call(value: "Missing") }
         .to raise_error(LinearToonMcp::Error, /\AThing not found: Missing\z/)
     end
   end

--- a/spec/linear_toon_mcp/resolvers/cycle_spec.rb
+++ b/spec/linear_toon_mcp/resolvers/cycle_spec.rb
@@ -5,13 +5,15 @@ RSpec.describe LinearToonMcp::Resolvers::Cycle do
   let(:uuid) { "12345678-1234-1234-1234-123456789012" }
   let(:team_id) { uuid }
 
+  before { LinearToonMcp.client = client }
+
   it "passes through UUIDs unchanged" do
-    expect(described_class.call(client, value: uuid, team_id: team_id)).to eq(uuid)
+    expect(described_class.call(value: uuid, team_id: team_id)).to eq(uuid)
   end
 
   it "uses the number filter for digit-only values" do
     allow(client).to receive(:query).and_return("cycles" => {"nodes" => [{"id" => "cycle-uuid"}]})
-    described_class.call(client, value: "42", team_id: team_id)
+    described_class.call(value: "42", team_id: team_id)
     expect(client).to have_received(:query).with(
       anything,
       variables: {filter: {number: {eq: 42}, team: {id: {eq: team_id}}}}
@@ -20,7 +22,7 @@ RSpec.describe LinearToonMcp::Resolvers::Cycle do
 
   it "uses the name filter otherwise" do
     allow(client).to receive(:query).and_return("cycles" => {"nodes" => [{"id" => "cycle-uuid"}]})
-    described_class.call(client, value: "Sprint 5", team_id: team_id)
+    described_class.call(value: "Sprint 5", team_id: team_id)
     expect(client).to have_received(:query).with(
       anything,
       variables: {filter: {name: {eqIgnoreCase: "Sprint 5"}, team: {id: {eq: team_id}}}}
@@ -29,12 +31,12 @@ RSpec.describe LinearToonMcp::Resolvers::Cycle do
 
   it "raises when cycle not found" do
     allow(client).to receive(:query).and_return("cycles" => {"nodes" => []})
-    expect { described_class.call(client, value: "Missing", team_id: team_id) }
+    expect { described_class.call(value: "Missing", team_id: team_id) }
       .to raise_error(LinearToonMcp::Error, /\ACycle not found: Missing\z/)
   end
 
   it "raises when team_id is missing" do
-    expect { described_class.call(client, value: "Sprint 5") }
+    expect { described_class.call(value: "Sprint 5") }
       .to raise_error(LinearToonMcp::Error, /Missing required scope: team_id/)
   end
 end

--- a/spec/linear_toon_mcp/resolvers/issue_label_spec.rb
+++ b/spec/linear_toon_mcp/resolvers/issue_label_spec.rb
@@ -5,13 +5,15 @@ RSpec.describe LinearToonMcp::Resolvers::IssueLabel do
   let(:uuid) { "12345678-1234-1234-1234-123456789012" }
   let(:team_id) { "team-uuid" }
 
+  before { LinearToonMcp.client = client }
+
   it "passes through UUIDs unchanged" do
-    expect(described_class.call(client, value: uuid)).to eq(uuid)
+    expect(described_class.call(value: uuid)).to eq(uuid)
   end
 
   it "uses a plain name filter when no team given" do
     allow(client).to receive(:query).and_return("issueLabels" => {"nodes" => [{"id" => "label-uuid"}]})
-    expect(described_class.call(client, value: "bug")).to eq("label-uuid")
+    expect(described_class.call(value: "bug")).to eq("label-uuid")
     expect(client).to have_received(:query).with(
       anything,
       variables: {filter: {name: {eqIgnoreCase: "bug"}}}
@@ -20,7 +22,7 @@ RSpec.describe LinearToonMcp::Resolvers::IssueLabel do
 
   it "scopes the lookup to the team or workspace-wide labels when team_id is given" do
     allow(client).to receive(:query).and_return("issueLabels" => {"nodes" => [{"id" => "label-uuid"}]})
-    described_class.call(client, value: "bug", team_id: team_id)
+    described_class.call(value: "bug", team_id: team_id)
     expect(client).to have_received(:query).with(
       anything,
       variables: {filter: {
@@ -35,13 +37,13 @@ RSpec.describe LinearToonMcp::Resolvers::IssueLabel do
 
   it "raises a team-aware error when label not found on team or workspace" do
     allow(client).to receive(:query).and_return("issueLabels" => {"nodes" => []})
-    expect { described_class.call(client, value: "Missing", team_id: team_id) }
+    expect { described_class.call(value: "Missing", team_id: team_id) }
       .to raise_error(LinearToonMcp::Error, /Label not found on target team or workspace: Missing/)
   end
 
   it "raises a plain error when label not found without team scope" do
     allow(client).to receive(:query).and_return("issueLabels" => {"nodes" => []})
-    expect { described_class.call(client, value: "Missing") }
+    expect { described_class.call(value: "Missing") }
       .to raise_error(LinearToonMcp::Error, /\ALabel not found: Missing\z/)
   end
 
@@ -51,17 +53,17 @@ RSpec.describe LinearToonMcp::Resolvers::IssueLabel do
         {"issueLabels" => {"nodes" => [{"id" => "l1"}]}},
         {"issueLabels" => {"nodes" => [{"id" => "l2"}]}}
       )
-      expect(described_class.call_many(client, values: ["bug", "feature"])).to eq(["l1", "l2"])
+      expect(described_class.call_many(values: ["bug", "feature"])).to eq(["l1", "l2"])
     end
 
     it "passes through UUIDs without querying" do
-      result = described_class.call_many(client, values: [uuid])
+      result = described_class.call_many(values: [uuid])
       expect(result).to eq([uuid])
     end
 
     it "forwards team_id to each per-label lookup" do
       allow(client).to receive(:query).and_return("issueLabels" => {"nodes" => [{"id" => "l1"}]})
-      described_class.call_many(client, values: ["bug"], team_id: team_id)
+      described_class.call_many(values: ["bug"], team_id: team_id)
       expect(client).to have_received(:query).with(
         anything,
         variables: {filter: {
@@ -76,14 +78,14 @@ RSpec.describe LinearToonMcp::Resolvers::IssueLabel do
 
     it "mixes UUIDs and names without re-querying the UUIDs" do
       allow(client).to receive(:query).and_return("issueLabels" => {"nodes" => [{"id" => "name-resolved"}]})
-      result = described_class.call_many(client, values: [uuid, "bug"], team_id: team_id)
+      result = described_class.call_many(values: [uuid, "bug"], team_id: team_id)
       expect(result).to eq([uuid, "name-resolved"])
       expect(client).to have_received(:query).once
     end
 
     it "returns an empty array without querying when given no labels" do
       allow(client).to receive(:query)
-      result = described_class.call_many(client, values: [], team_id: team_id)
+      result = described_class.call_many(values: [], team_id: team_id)
       expect(result).to eq([])
       expect(client).not_to have_received(:query)
     end

--- a/spec/linear_toon_mcp/resolvers/project_milestone_spec.rb
+++ b/spec/linear_toon_mcp/resolvers/project_milestone_spec.rb
@@ -5,13 +5,15 @@ RSpec.describe LinearToonMcp::Resolvers::ProjectMilestone do
   let(:uuid) { "12345678-1234-1234-1234-123456789012" }
   let(:project_id) { uuid }
 
+  before { LinearToonMcp.client = client }
+
   it "passes through UUIDs unchanged" do
-    expect(described_class.call(client, value: uuid, project_id: project_id)).to eq(uuid)
+    expect(described_class.call(value: uuid, project_id: project_id)).to eq(uuid)
   end
 
   it "scopes the filter by project" do
     allow(client).to receive(:query).and_return("projectMilestones" => {"nodes" => [{"id" => "ms-uuid"}]})
-    expect(described_class.call(client, value: "MVP", project_id: project_id)).to eq("ms-uuid")
+    expect(described_class.call(value: "MVP", project_id: project_id)).to eq("ms-uuid")
     expect(client).to have_received(:query).with(
       anything,
       variables: {filter: {name: {eqIgnoreCase: "MVP"}, project: {id: {eq: project_id}}}}
@@ -20,12 +22,12 @@ RSpec.describe LinearToonMcp::Resolvers::ProjectMilestone do
 
   it "raises when milestone not found" do
     allow(client).to receive(:query).and_return("projectMilestones" => {"nodes" => []})
-    expect { described_class.call(client, value: "Missing", project_id: project_id) }
+    expect { described_class.call(value: "Missing", project_id: project_id) }
       .to raise_error(LinearToonMcp::Error, /\AMilestone not found: Missing\z/)
   end
 
   it "raises when project_id is missing" do
-    expect { described_class.call(client, value: "MVP") }
+    expect { described_class.call(value: "MVP") }
       .to raise_error(LinearToonMcp::Error, /Missing required scope: project_id/)
   end
 end

--- a/spec/linear_toon_mcp/resolvers/project_spec.rb
+++ b/spec/linear_toon_mcp/resolvers/project_spec.rb
@@ -4,19 +4,21 @@ RSpec.describe LinearToonMcp::Resolvers::Project do
   let(:client) { instance_double(LinearToonMcp::Client) }
   let(:uuid) { "12345678-1234-1234-1234-123456789012" }
 
+  before { LinearToonMcp.client = client }
+
   it "passes through UUIDs unchanged" do
-    expect(described_class.call(client, value: uuid)).to eq(uuid)
+    expect(described_class.call(value: uuid)).to eq(uuid)
   end
 
   it "resolves via the name filter" do
     allow(client).to receive(:query).and_return("projects" => {"nodes" => [{"id" => "proj-uuid"}]})
-    expect(described_class.call(client, value: "My Project")).to eq("proj-uuid")
+    expect(described_class.call(value: "My Project")).to eq("proj-uuid")
   end
 
   it "falls back to slugId when name yields no result" do
     allow(client).to receive(:query)
       .and_return({"projects" => {"nodes" => []}}, {"projects" => {"nodes" => [{"id" => "proj-uuid"}]}})
-    expect(described_class.call(client, value: "my-project")).to eq("proj-uuid")
+    expect(described_class.call(value: "my-project")).to eq("proj-uuid")
     expect(client).to have_received(:query).with(
       anything,
       variables: {filter: {slugId: {eqIgnoreCase: "my-project"}}}
@@ -25,7 +27,7 @@ RSpec.describe LinearToonMcp::Resolvers::Project do
 
   it "raises when project not found by name or slug" do
     allow(client).to receive(:query).and_return("projects" => {"nodes" => []})
-    expect { described_class.call(client, value: "Missing") }
+    expect { described_class.call(value: "Missing") }
       .to raise_error(LinearToonMcp::Error, /\AProject not found: Missing\z/)
   end
 end

--- a/spec/linear_toon_mcp/resolvers/team_spec.rb
+++ b/spec/linear_toon_mcp/resolvers/team_spec.rb
@@ -4,13 +4,15 @@ RSpec.describe LinearToonMcp::Resolvers::Team do
   let(:client) { instance_double(LinearToonMcp::Client) }
   let(:uuid) { "12345678-1234-1234-1234-123456789012" }
 
+  before { LinearToonMcp.client = client }
+
   it "passes through UUIDs unchanged" do
-    expect(described_class.call(client, value: uuid)).to eq(uuid)
+    expect(described_class.call(value: uuid)).to eq(uuid)
   end
 
   it "resolves a name via the name filter" do
     allow(client).to receive(:query).and_return("teams" => {"nodes" => [{"id" => uuid}]})
-    expect(described_class.call(client, value: "Engineering")).to eq(uuid)
+    expect(described_class.call(value: "Engineering")).to eq(uuid)
     expect(client).to have_received(:query).with(
       anything,
       variables: {filter: {name: {eqIgnoreCase: "Engineering"}}}
@@ -19,7 +21,7 @@ RSpec.describe LinearToonMcp::Resolvers::Team do
 
   it "resolves an uppercase team key via the key filter" do
     allow(client).to receive(:query).and_return("teams" => {"nodes" => [{"id" => uuid}]})
-    expect(described_class.call(client, value: "ENG")).to eq(uuid)
+    expect(described_class.call(value: "ENG")).to eq(uuid)
     expect(client).to have_received(:query).with(
       anything,
       variables: {filter: {key: {eq: "ENG"}}}
@@ -29,7 +31,7 @@ RSpec.describe LinearToonMcp::Resolvers::Team do
   it "falls back to the name filter when the key lookup misses" do
     allow(client).to receive(:query)
       .and_return({"teams" => {"nodes" => []}}, {"teams" => {"nodes" => [{"id" => uuid}]}})
-    expect(described_class.call(client, value: "ENG")).to eq(uuid)
+    expect(described_class.call(value: "ENG")).to eq(uuid)
     expect(client).to have_received(:query).with(
       anything,
       variables: {filter: {name: {eqIgnoreCase: "ENG"}}}
@@ -38,7 +40,7 @@ RSpec.describe LinearToonMcp::Resolvers::Team do
 
   it "raises when team not found" do
     allow(client).to receive(:query).and_return("teams" => {"nodes" => []})
-    expect { described_class.call(client, value: "Missing") }
+    expect { described_class.call(value: "Missing") }
       .to raise_error(LinearToonMcp::Error, /\ATeam not found: Missing\z/)
   end
 end

--- a/spec/linear_toon_mcp/resolvers/user_spec.rb
+++ b/spec/linear_toon_mcp/resolvers/user_spec.rb
@@ -4,24 +4,26 @@ RSpec.describe LinearToonMcp::Resolvers::User do
   let(:client) { instance_double(LinearToonMcp::Client) }
   let(:uuid) { "12345678-1234-1234-1234-123456789012" }
 
+  before { LinearToonMcp.client = client }
+
   it "passes through UUIDs unchanged" do
-    expect(described_class.call(client, value: uuid)).to eq(uuid)
+    expect(described_class.call(value: uuid)).to eq(uuid)
   end
 
   it "resolves 'me' through the viewer shortcut" do
     allow(client).to receive(:query).and_return("viewer" => {"id" => uuid})
-    expect(described_class.call(client, value: "me")).to eq(uuid)
+    expect(described_class.call(value: "me")).to eq(uuid)
   end
 
   it "raises when viewer returns no id" do
     allow(client).to receive(:query).and_return("viewer" => {})
-    expect { described_class.call(client, value: "me") }
+    expect { described_class.call(value: "me") }
       .to raise_error(LinearToonMcp::Error, /Could not resolve current user/)
   end
 
   it "uses the email filter when the value contains '@'" do
     allow(client).to receive(:query).and_return("users" => {"nodes" => [{"id" => uuid}]})
-    described_class.call(client, value: "alice@example.com")
+    described_class.call(value: "alice@example.com")
     expect(client).to have_received(:query).with(
       anything,
       variables: {filter: {email: {eq: "alice@example.com"}}}
@@ -30,7 +32,7 @@ RSpec.describe LinearToonMcp::Resolvers::User do
 
   it "falls back to the name filter otherwise" do
     allow(client).to receive(:query).and_return("users" => {"nodes" => [{"id" => uuid}]})
-    described_class.call(client, value: "Alice")
+    described_class.call(value: "Alice")
     expect(client).to have_received(:query).with(
       anything,
       variables: {filter: {name: {eqIgnoreCase: "Alice"}}}
@@ -39,7 +41,7 @@ RSpec.describe LinearToonMcp::Resolvers::User do
 
   it "raises when user not found" do
     allow(client).to receive(:query).and_return("users" => {"nodes" => []})
-    expect { described_class.call(client, value: "Nobody") }
+    expect { described_class.call(value: "Nobody") }
       .to raise_error(LinearToonMcp::Error, /\AUser not found: Nobody\z/)
   end
 end

--- a/spec/linear_toon_mcp/resolvers/workflow_state_spec.rb
+++ b/spec/linear_toon_mcp/resolvers/workflow_state_spec.rb
@@ -5,13 +5,15 @@ RSpec.describe LinearToonMcp::Resolvers::WorkflowState do
   let(:uuid) { "12345678-1234-1234-1234-123456789012" }
   let(:team_id) { uuid }
 
+  before { LinearToonMcp.client = client }
+
   it "passes through UUIDs unchanged" do
-    expect(described_class.call(client, value: uuid, team_id: team_id)).to eq(uuid)
+    expect(described_class.call(value: uuid, team_id: team_id)).to eq(uuid)
   end
 
   it "scopes the filter by team" do
     allow(client).to receive(:query).and_return("workflowStates" => {"nodes" => [{"id" => "state-uuid"}]})
-    expect(described_class.call(client, value: "In Progress", team_id: team_id)).to eq("state-uuid")
+    expect(described_class.call(value: "In Progress", team_id: team_id)).to eq("state-uuid")
     expect(client).to have_received(:query).with(
       anything,
       variables: {filter: {name: {eqIgnoreCase: "In Progress"}, team: {id: {eq: team_id}}}}
@@ -20,7 +22,7 @@ RSpec.describe LinearToonMcp::Resolvers::WorkflowState do
 
   it "resolves a lowercase enum value via the type filter" do
     allow(client).to receive(:query).and_return("workflowStates" => {"nodes" => [{"id" => "state-uuid"}]})
-    expect(described_class.call(client, value: "started", team_id: team_id)).to eq("state-uuid")
+    expect(described_class.call(value: "started", team_id: team_id)).to eq("state-uuid")
     expect(client).to have_received(:query).with(
       anything,
       variables: {filter: {type: {eq: "started"}, team: {id: {eq: team_id}}}}
@@ -29,7 +31,7 @@ RSpec.describe LinearToonMcp::Resolvers::WorkflowState do
 
   it "treats capitalized enum tokens as names (no type collision)" do
     allow(client).to receive(:query).and_return("workflowStates" => {"nodes" => [{"id" => "state-uuid"}]})
-    described_class.call(client, value: "Started", team_id: team_id)
+    described_class.call(value: "Started", team_id: team_id)
     expect(client).to have_received(:query).with(
       anything,
       variables: {filter: {name: {eqIgnoreCase: "Started"}, team: {id: {eq: team_id}}}}
@@ -38,12 +40,12 @@ RSpec.describe LinearToonMcp::Resolvers::WorkflowState do
 
   it "raises when state not found" do
     allow(client).to receive(:query).and_return("workflowStates" => {"nodes" => []})
-    expect { described_class.call(client, value: "Missing", team_id: team_id) }
+    expect { described_class.call(value: "Missing", team_id: team_id) }
       .to raise_error(LinearToonMcp::Error, /\AState not found: Missing\z/)
   end
 
   it "raises when team_id is missing" do
-    expect { described_class.call(client, value: "In Progress") }
+    expect { described_class.call(value: "In Progress") }
       .to raise_error(LinearToonMcp::Error, /Missing required scope: team_id/)
   end
 end

--- a/spec/linear_toon_mcp/server_spec.rb
+++ b/spec/linear_toon_mcp/server_spec.rb
@@ -2,7 +2,9 @@
 
 RSpec.describe LinearToonMcp, ".server" do
   let(:client) { instance_double(LinearToonMcp::Client) }
-  let(:server) { described_class.server(client:) }
+  let(:server) { described_class.server }
+
+  before { described_class.client = client }
 
   describe "initialize" do
     subject(:result) do

--- a/spec/linear_toon_mcp/tools/base_spec.rb
+++ b/spec/linear_toon_mcp/tools/base_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+RSpec.describe LinearToonMcp::Tools::Base do
+  let(:client) { instance_double(LinearToonMcp::Client) }
+
+  before { LinearToonMcp.client = client }
+
+  let(:tool) do
+    Class.new(described_class) do
+      def perform(value: "ok")
+        {"value" => value}
+      end
+    end
+  end
+
+  describe ".call" do
+    it "instantiates the tool, runs perform, and TOON-encodes the result" do
+      response = tool.call(value: "hello")
+      expect(response).to be_a(MCP::Tool::Response)
+      expect(response.content.first[:type]).to eq("text")
+      expect(response.content.first[:text]).to include("hello")
+    end
+
+    it "ignores server_context (the client comes from LinearToonMcp.client)" do
+      response = tool.call(server_context: {other: :thing}, value: "ok")
+      expect(response).to be_a(MCP::Tool::Response)
+    end
+
+    it "returns an error response when perform raises Error" do
+      failing = Class.new(described_class) do
+        def perform(**)
+          raise LinearToonMcp::Error, "boom"
+        end
+      end
+      response = failing.call
+      expect(response).to be_a(MCP::Tool::Response).and be_error
+      expect(response.content.first[:text]).to eq("boom")
+    end
+  end
+
+  describe "#perform" do
+    it "raises NotImplementedError by default" do
+      expect { described_class.new.perform }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe "#client" do
+    it "returns the active LinearToonMcp client" do
+      expect(tool.new.send(:client)).to eq(client)
+    end
+  end
+end

--- a/spec/linear_toon_mcp/tools/create_comment_spec.rb
+++ b/spec/linear_toon_mcp/tools/create_comment_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe LinearToonMcp::Tools::CreateComment do
     end
 
     before do
+      LinearToonMcp.client = client
       allow(client).to receive(:query).and_return(
         "commentCreate" => {"success" => true, "comment" => comment_data}
       )
@@ -58,15 +59,6 @@ RSpec.describe LinearToonMcp::Tools::CreateComment do
       it "returns an error response" do
         expect(response).to be_a(MCP::Tool::Response).and be_error
         expect(response.content.first[:text]).to include("failed")
-      end
-    end
-
-    context "when server_context has no client" do
-      subject(:response) { described_class.call(**params, server_context: {}) }
-
-      it "returns an error response" do
-        expect(response).to be_a(MCP::Tool::Response).and be_error
-        expect(response.content.first[:text]).to include("client missing")
       end
     end
 

--- a/spec/linear_toon_mcp/tools/create_issue_spec.rb
+++ b/spec/linear_toon_mcp/tools/create_issue_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe LinearToonMcp::Tools::CreateIssue do
     end
 
     before do
-      allow(LinearToonMcp::Resolvers::Team).to receive(:call).with(client, value: team_id).and_return(team_id)
+      LinearToonMcp.client = client
+      allow(LinearToonMcp::Resolvers::Team).to receive(:call).with(value: team_id).and_return(team_id)
       allow(client).to receive(:query).and_return(
         "issueCreate" => {"success" => true, "issue" => issue_data}
       )
@@ -61,12 +62,12 @@ RSpec.describe LinearToonMcp::Tools::CreateIssue do
       let(:params) { {title: "New issue", team: "Engineering", assignee: "Alice", state: "In Progress", labels: ["bug", "urgent"], project: "My Project", cycle: "Sprint 5"} }
 
       before do
-        allow(LinearToonMcp::Resolvers::Team).to receive(:call).with(client, value: "Engineering").and_return(team_id)
-        allow(LinearToonMcp::Resolvers::User).to receive(:call).with(client, value: "Alice").and_return("user-uuid")
-        allow(LinearToonMcp::Resolvers::WorkflowState).to receive(:call).with(client, value: "In Progress", team_id: team_id).and_return("state-uuid")
-        allow(LinearToonMcp::Resolvers::IssueLabel).to receive(:call_many).with(client, values: ["bug", "urgent"], team_id: team_id).and_return(["l1", "l2"])
-        allow(LinearToonMcp::Resolvers::Project).to receive(:call).with(client, value: "My Project").and_return("proj-uuid")
-        allow(LinearToonMcp::Resolvers::Cycle).to receive(:call).with(client, value: "Sprint 5", team_id: team_id).and_return("cycle-uuid")
+        allow(LinearToonMcp::Resolvers::Team).to receive(:call).with(value: "Engineering").and_return(team_id)
+        allow(LinearToonMcp::Resolvers::User).to receive(:call).with(value: "Alice").and_return("user-uuid")
+        allow(LinearToonMcp::Resolvers::WorkflowState).to receive(:call).with(value: "In Progress", team_id: team_id).and_return("state-uuid")
+        allow(LinearToonMcp::Resolvers::IssueLabel).to receive(:call_many).with(values: ["bug", "urgent"], team_id: team_id).and_return(["l1", "l2"])
+        allow(LinearToonMcp::Resolvers::Project).to receive(:call).with(value: "My Project").and_return("proj-uuid")
+        allow(LinearToonMcp::Resolvers::Cycle).to receive(:call).with(value: "Sprint 5", team_id: team_id).and_return("cycle-uuid")
       end
 
       it "resolves names and passes IDs to mutation" do
@@ -85,8 +86,8 @@ RSpec.describe LinearToonMcp::Tools::CreateIssue do
       let(:params) { {title: "New issue", team: team_id, project: "My Project", milestone: "MVP"} }
 
       before do
-        allow(LinearToonMcp::Resolvers::Project).to receive(:call).with(client, value: "My Project").and_return("proj-uuid")
-        allow(LinearToonMcp::Resolvers::ProjectMilestone).to receive(:call).with(client, value: "MVP", project_id: "proj-uuid").and_return("ms-uuid")
+        allow(LinearToonMcp::Resolvers::Project).to receive(:call).with(value: "My Project").and_return("proj-uuid")
+        allow(LinearToonMcp::Resolvers::ProjectMilestone).to receive(:call).with(value: "MVP", project_id: "proj-uuid").and_return("ms-uuid")
       end
 
       it "resolves milestone using project_id" do
@@ -102,7 +103,7 @@ RSpec.describe LinearToonMcp::Tools::CreateIssue do
       let(:params) { {title: "New issue", team: team_id, delegate: "Alice"} }
 
       before do
-        allow(LinearToonMcp::Resolvers::User).to receive(:call).with(client, value: "Alice").and_return("user-uuid")
+        allow(LinearToonMcp::Resolvers::User).to receive(:call).with(value: "Alice").and_return("user-uuid")
       end
 
       it "resolves delegate as user" do
@@ -279,15 +280,6 @@ RSpec.describe LinearToonMcp::Tools::CreateIssue do
       it "returns an error response" do
         expect(response).to be_a(MCP::Tool::Response).and be_error
         expect(response.content.first[:text]).to include("Team not found")
-      end
-    end
-
-    context "when server_context has no client" do
-      subject(:response) { described_class.call(**params, server_context: {}) }
-
-      it "returns an error response" do
-        expect(response).to be_a(MCP::Tool::Response).and be_error
-        expect(response.content.first[:text]).to include("client missing")
       end
     end
 

--- a/spec/linear_toon_mcp/tools/create_spec.rb
+++ b/spec/linear_toon_mcp/tools/create_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+RSpec.describe LinearToonMcp::Tools::Create do
+  let(:client) { instance_double(LinearToonMcp::Client) }
+
+  before { LinearToonMcp.client = client }
+
+  describe "conventions derived from class name" do
+    it "camelCases the entity from the class name, dropping the Create prefix" do
+      expect(LinearToonMcp::Tools::CreateIssue.entity_name).to eq("issue")
+      expect(LinearToonMcp::Tools::CreateComment.entity_name).to eq("comment")
+    end
+
+    it "appends Create to the entity for the mutation field" do
+      expect(LinearToonMcp::Tools::CreateIssue.mutation_name).to eq("issueCreate")
+      expect(LinearToonMcp::Tools::CreateComment.mutation_name).to eq("commentCreate")
+    end
+
+    it "uses the stripped class name as the entity label" do
+      expect(LinearToonMcp::Tools::CreateIssue.entity_label).to eq("Issue")
+      expect(LinearToonMcp::Tools::CreateComment.entity_label).to eq("Comment")
+    end
+  end
+
+  describe "#perform" do
+    let(:tool) do
+      Class.new(described_class) do
+        const_set(:MUTATION, "mutation { thingCreate { success thing { id } } }")
+
+        class << self
+          def entity_name
+            "thing"
+          end
+
+          def mutation_name
+            "thingCreate"
+          end
+
+          def entity_label
+            "Thing"
+          end
+        end
+
+        def variables(**)
+          {}
+        end
+      end
+    end
+
+    it "submits the mutation and returns the created entity" do
+      allow(client).to receive(:query)
+        .and_return("thingCreate" => {"success" => true, "thing" => {"id" => "1"}})
+      expect(tool.new.perform).to eq("id" => "1")
+    end
+
+    it "raises when the mutation payload is missing" do
+      allow(client).to receive(:query).and_return({})
+      expect { tool.new.perform }
+        .to raise_error(LinearToonMcp::Error, /Thing creation failed: no result returned/)
+    end
+
+    it "raises when success is false" do
+      allow(client).to receive(:query)
+        .and_return("thingCreate" => {"success" => false, "thing" => nil})
+      expect { tool.new.perform }
+        .to raise_error(LinearToonMcp::Error, /\AThing creation failed\z/)
+    end
+  end
+end

--- a/spec/linear_toon_mcp/tools/get_issue_spec.rb
+++ b/spec/linear_toon_mcp/tools/get_issue_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe LinearToonMcp::Tools::GetIssue do
     end
 
     before do
+      LinearToonMcp.client = client
       allow(client).to receive(:query).and_return("issue" => issue_data)
     end
 
@@ -117,15 +118,6 @@ RSpec.describe LinearToonMcp::Tools::GetIssue do
       it "returns an error response" do
         expect(response).to be_a(MCP::Tool::Response).and be_error
         expect(response.content.first[:text]).to include("Issue not found: TEST-1")
-      end
-    end
-
-    context "when server_context has no client" do
-      subject(:response) { described_class.call(id:, server_context: {}) }
-
-      it "returns an error response" do
-        expect(response).to be_a(MCP::Tool::Response).and be_error
-        expect(response.content.first[:text]).to include("client missing")
       end
     end
 

--- a/spec/linear_toon_mcp/tools/get_project_spec.rb
+++ b/spec/linear_toon_mcp/tools/get_project_spec.rb
@@ -32,7 +32,8 @@ RSpec.describe LinearToonMcp::Tools::GetProject do
     end
 
     before do
-      allow(LinearToonMcp::Resolvers::Project).to receive(:call).with(client, value: query).and_return(project_id)
+      LinearToonMcp.client = client
+      allow(LinearToonMcp::Resolvers::Project).to receive(:call).with(value: query).and_return(project_id)
       allow(client).to receive(:query).and_return("project" => project_data)
     end
 
@@ -45,7 +46,7 @@ RSpec.describe LinearToonMcp::Tools::GetProject do
 
     it "resolves project by query and queries Linear" do
       response
-      expect(LinearToonMcp::Resolvers::Project).to have_received(:call).with(client, value: "My Project")
+      expect(LinearToonMcp::Resolvers::Project).to have_received(:call).with(value: "My Project")
       expect(client).to have_received(:query).with(
         a_string_matching(/project\(id: \$id\)/),
         variables: {id: project_id}
@@ -56,12 +57,12 @@ RSpec.describe LinearToonMcp::Tools::GetProject do
       let(:query) { project_id }
 
       before do
-        allow(LinearToonMcp::Resolvers::Project).to receive(:call).with(client, value: project_id).and_return(project_id)
+        allow(LinearToonMcp::Resolvers::Project).to receive(:call).with(value: project_id).and_return(project_id)
       end
 
       it "passes UUID through resolver" do
         response
-        expect(LinearToonMcp::Resolvers::Project).to have_received(:call).with(client, value: project_id)
+        expect(LinearToonMcp::Resolvers::Project).to have_received(:call).with(value: project_id)
       end
     end
 
@@ -69,12 +70,12 @@ RSpec.describe LinearToonMcp::Tools::GetProject do
       let(:query) { "my-project" }
 
       before do
-        allow(LinearToonMcp::Resolvers::Project).to receive(:call).with(client, value: "my-project").and_return(project_id)
+        allow(LinearToonMcp::Resolvers::Project).to receive(:call).with(value: "my-project").and_return(project_id)
       end
 
       it "resolves slug through resolver" do
         response
-        expect(LinearToonMcp::Resolvers::Project).to have_received(:call).with(client, value: "my-project")
+        expect(LinearToonMcp::Resolvers::Project).to have_received(:call).with(value: "my-project")
       end
     end
 
@@ -173,15 +174,6 @@ RSpec.describe LinearToonMcp::Tools::GetProject do
       it "returns an error response" do
         expect(response).to be_a(MCP::Tool::Response).and be_error
         expect(response.content.first[:text]).to include("Project not found: My Project")
-      end
-    end
-
-    context "when server_context has no client" do
-      subject(:response) { described_class.call(query:, server_context: {}) }
-
-      it "returns an error response" do
-        expect(response).to be_a(MCP::Tool::Response).and be_error
-        expect(response.content.first[:text]).to include("client missing")
       end
     end
 

--- a/spec/linear_toon_mcp/tools/get_spec.rb
+++ b/spec/linear_toon_mcp/tools/get_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+RSpec.describe LinearToonMcp::Tools::Get do
+  let(:client) { instance_double(LinearToonMcp::Client) }
+
+  before { LinearToonMcp.client = client }
+
+  describe "conventions derived from class name" do
+    it "camelCases the leading word, dropping the Get prefix" do
+      expect(LinearToonMcp::Tools::GetIssue.entity_name).to eq("issue")
+      expect(LinearToonMcp::Tools::GetProject.entity_name).to eq("project")
+    end
+
+    it "uses the stripped class name as the not-found label" do
+      expect(LinearToonMcp::Tools::GetIssue.entity_label).to eq("Issue")
+      expect(LinearToonMcp::Tools::GetProject.entity_label).to eq("Project")
+    end
+  end
+
+  describe "#perform" do
+    let(:tool) do
+      Class.new(described_class) do
+        const_set(:QUERY, "query($id: String!) { thing(id: $id) { id } }")
+
+        class << self
+          def entity_name
+            "thing"
+          end
+
+          def entity_label
+            "Thing"
+          end
+        end
+      end
+    end
+
+    it "queries with id and returns the entity" do
+      allow(client).to receive(:query).and_return("thing" => {"id" => "1"})
+      expect(tool.new.perform(id: "1")).to eq("id" => "1")
+    end
+
+    it "raises a labeled not-found error when the entity is nil" do
+      allow(client).to receive(:query).and_return("thing" => nil)
+      expect { tool.new.perform(id: "missing") }
+        .to raise_error(LinearToonMcp::Error, /\AThing not found: missing\z/)
+    end
+  end
+end

--- a/spec/linear_toon_mcp/tools/list_comments_spec.rb
+++ b/spec/linear_toon_mcp/tools/list_comments_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe LinearToonMcp::Tools::ListComments do
     end
 
     before do
+      LinearToonMcp.client = client
       allow(client).to receive(:query).and_return("issue" => {"comments" => comments_data})
     end
 
@@ -69,15 +70,6 @@ RSpec.describe LinearToonMcp::Tools::ListComments do
       it "returns an error response" do
         expect(response).to be_a(MCP::Tool::Response).and be_error
         expect(response.content.first[:text]).to include("Issue not found: TEST-1")
-      end
-    end
-
-    context "when server_context has no client" do
-      subject(:response) { described_class.call(issueId: issue_id, server_context: {}) }
-
-      it "returns an error response" do
-        expect(response).to be_a(MCP::Tool::Response).and be_error
-        expect(response.content.first[:text]).to include("client missing")
       end
     end
 

--- a/spec/linear_toon_mcp/tools/list_cycles_spec.rb
+++ b/spec/linear_toon_mcp/tools/list_cycles_spec.rb
@@ -17,13 +17,14 @@ RSpec.describe LinearToonMcp::Tools::ListCycles do
     end
 
     before do
-      allow(LinearToonMcp::Resolvers::Team).to receive(:call).with(client, value: team).and_return(team_id)
+      LinearToonMcp.client = client
+      allow(LinearToonMcp::Resolvers::Team).to receive(:call).with(value: team).and_return(team_id)
       allow(client).to receive(:query).and_return("cycles" => cycles_data)
     end
 
     it "resolves the team and queries cycles" do
       response
-      expect(LinearToonMcp::Resolvers::Team).to have_received(:call).with(client, value: team)
+      expect(LinearToonMcp::Resolvers::Team).to have_received(:call).with(value: team)
       expect(client).to have_received(:query).with(
         described_class::QUERY,
         variables: {filter: {team: {id: {eq: team_id}}}}
@@ -43,12 +44,12 @@ RSpec.describe LinearToonMcp::Tools::ListCycles do
       let(:team) { "12345678-1234-1234-1234-123456789012" }
 
       before do
-        allow(LinearToonMcp::Resolvers::Team).to receive(:call).with(client, value: team).and_return(team)
+        allow(LinearToonMcp::Resolvers::Team).to receive(:call).with(value: team).and_return(team)
       end
 
       it "passes UUID through the resolver" do
         response
-        expect(LinearToonMcp::Resolvers::Team).to have_received(:call).with(client, value: team)
+        expect(LinearToonMcp::Resolvers::Team).to have_received(:call).with(value: team)
       end
     end
 
@@ -85,15 +86,6 @@ RSpec.describe LinearToonMcp::Tools::ListCycles do
       it "returns an error response" do
         expect(response).to be_a(MCP::Tool::Response).and be_error
         expect(response.content.first[:text]).to include("Unexpected response")
-      end
-    end
-
-    context "when server_context has no client" do
-      subject(:response) { described_class.call(team: "Engineering", server_context: {}) }
-
-      it "returns an error response" do
-        expect(response).to be_a(MCP::Tool::Response).and be_error
-        expect(response.content.first[:text]).to include("client missing")
       end
     end
 

--- a/spec/linear_toon_mcp/tools/list_issue_labels_spec.rb
+++ b/spec/linear_toon_mcp/tools/list_issue_labels_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe LinearToonMcp::Tools::ListIssueLabels do
     end
 
     before do
+      LinearToonMcp.client = client
       allow(client).to receive(:query).and_return("issueLabels" => labels_data)
     end
 
@@ -37,13 +38,13 @@ RSpec.describe LinearToonMcp::Tools::ListIssueLabels do
       let(:team_id) { "12345678-1234-1234-1234-123456789012" }
 
       before do
-        allow(LinearToonMcp::Resolvers::Team).to receive(:call).with(client, value: "Engineering").and_return(team_id)
+        allow(LinearToonMcp::Resolvers::Team).to receive(:call).with(value: "Engineering").and_return(team_id)
         allow(client).to receive(:query).and_return("issueLabels" => labels_data)
       end
 
       it "resolves the team and queries with team filter" do
         response
-        expect(LinearToonMcp::Resolvers::Team).to have_received(:call).with(client, value: "Engineering")
+        expect(LinearToonMcp::Resolvers::Team).to have_received(:call).with(value: "Engineering")
         expect(client).to have_received(:query).with(
           described_class::QUERY,
           variables: {filter: {team: {id: {eq: team_id}}}}
@@ -62,13 +63,13 @@ RSpec.describe LinearToonMcp::Tools::ListIssueLabels do
       let(:team_id) { "12345678-1234-1234-1234-123456789012" }
 
       before do
-        allow(LinearToonMcp::Resolvers::Team).to receive(:call).with(client, value: team_id).and_return(team_id)
+        allow(LinearToonMcp::Resolvers::Team).to receive(:call).with(value: team_id).and_return(team_id)
         allow(client).to receive(:query).and_return("issueLabels" => labels_data)
       end
 
       it "passes UUID through the resolver" do
         response
-        expect(LinearToonMcp::Resolvers::Team).to have_received(:call).with(client, value: team_id)
+        expect(LinearToonMcp::Resolvers::Team).to have_received(:call).with(value: team_id)
       end
     end
 
@@ -105,15 +106,6 @@ RSpec.describe LinearToonMcp::Tools::ListIssueLabels do
       it "returns an error response" do
         expect(response).to be_a(MCP::Tool::Response).and be_error
         expect(response.content.first[:text]).to include("Unexpected response")
-      end
-    end
-
-    context "when server_context has no client" do
-      subject(:response) { described_class.call(server_context: {}) }
-
-      it "returns an error response" do
-        expect(response).to be_a(MCP::Tool::Response).and be_error
-        expect(response.content.first[:text]).to include("client missing")
       end
     end
 

--- a/spec/linear_toon_mcp/tools/list_issue_statuses_spec.rb
+++ b/spec/linear_toon_mcp/tools/list_issue_statuses_spec.rb
@@ -20,13 +20,14 @@ RSpec.describe LinearToonMcp::Tools::ListIssueStatuses do
     end
 
     before do
-      allow(LinearToonMcp::Resolvers::Team).to receive(:call).with(client, value: team).and_return(team_id)
+      LinearToonMcp.client = client
+      allow(LinearToonMcp::Resolvers::Team).to receive(:call).with(value: team).and_return(team_id)
       allow(client).to receive(:query).and_return("workflowStates" => states_data)
     end
 
     it "resolves the team and queries workflow states" do
       response
-      expect(LinearToonMcp::Resolvers::Team).to have_received(:call).with(client, value: team)
+      expect(LinearToonMcp::Resolvers::Team).to have_received(:call).with(value: team)
       expect(client).to have_received(:query).with(
         described_class::QUERY,
         variables: {filter: {team: {id: {eq: team_id}}}}
@@ -46,12 +47,12 @@ RSpec.describe LinearToonMcp::Tools::ListIssueStatuses do
       let(:team) { "12345678-1234-1234-1234-123456789012" }
 
       before do
-        allow(LinearToonMcp::Resolvers::Team).to receive(:call).with(client, value: team).and_return(team)
+        allow(LinearToonMcp::Resolvers::Team).to receive(:call).with(value: team).and_return(team)
       end
 
       it "passes UUID through the resolver" do
         response
-        expect(LinearToonMcp::Resolvers::Team).to have_received(:call).with(client, value: team)
+        expect(LinearToonMcp::Resolvers::Team).to have_received(:call).with(value: team)
       end
     end
 
@@ -88,15 +89,6 @@ RSpec.describe LinearToonMcp::Tools::ListIssueStatuses do
       it "returns an error response" do
         expect(response).to be_a(MCP::Tool::Response).and be_error
         expect(response.content.first[:text]).to include("Unexpected response")
-      end
-    end
-
-    context "when server_context has no client" do
-      subject(:response) { described_class.call(team: "Engineering", server_context: {}) }
-
-      it "returns an error response" do
-        expect(response).to be_a(MCP::Tool::Response).and be_error
-        expect(response.content.first[:text]).to include("client missing")
       end
     end
 

--- a/spec/linear_toon_mcp/tools/list_issues_spec.rb
+++ b/spec/linear_toon_mcp/tools/list_issues_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe LinearToonMcp::Tools::ListIssues do
     end
 
     before do
+      LinearToonMcp.client = client
       allow(client).to receive(:query).and_return("issues" => issues_data)
     end
 
@@ -436,15 +437,6 @@ RSpec.describe LinearToonMcp::Tools::ListIssues do
       it "returns an error response" do
         expect(response).to be_a(MCP::Tool::Response).and be_error
         expect(response.content.first[:text]).to include("Unexpected response")
-      end
-    end
-
-    context "when server_context has no client" do
-      subject(:response) { described_class.call(server_context: {}) }
-
-      it "returns an error response" do
-        expect(response).to be_a(MCP::Tool::Response).and be_error
-        expect(response.content.first[:text]).to include("client missing")
       end
     end
 

--- a/spec/linear_toon_mcp/tools/list_projects_spec.rb
+++ b/spec/linear_toon_mcp/tools/list_projects_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe LinearToonMcp::Tools::ListProjects do
     end
 
     before do
+      LinearToonMcp.client = client
       allow(client).to receive(:query).and_return("projects" => projects_data)
     end
 
@@ -38,13 +39,13 @@ RSpec.describe LinearToonMcp::Tools::ListProjects do
       let(:team_id) { "12345678-1234-1234-1234-123456789012" }
 
       before do
-        allow(LinearToonMcp::Resolvers::Team).to receive(:call).with(client, value: "Engineering").and_return(team_id)
+        allow(LinearToonMcp::Resolvers::Team).to receive(:call).with(value: "Engineering").and_return(team_id)
         allow(client).to receive(:query).and_return("projects" => projects_data)
       end
 
       it "resolves the team and queries with team filter" do
         response
-        expect(LinearToonMcp::Resolvers::Team).to have_received(:call).with(client, value: "Engineering")
+        expect(LinearToonMcp::Resolvers::Team).to have_received(:call).with(value: "Engineering")
         expect(client).to have_received(:query).with(
           described_class::QUERY,
           variables: {filter: {accessibleTeams: {id: {eq: team_id}}}}
@@ -63,13 +64,13 @@ RSpec.describe LinearToonMcp::Tools::ListProjects do
       let(:team_id) { "12345678-1234-1234-1234-123456789012" }
 
       before do
-        allow(LinearToonMcp::Resolvers::Team).to receive(:call).with(client, value: team_id).and_return(team_id)
+        allow(LinearToonMcp::Resolvers::Team).to receive(:call).with(value: team_id).and_return(team_id)
         allow(client).to receive(:query).and_return("projects" => projects_data)
       end
 
       it "passes UUID through the resolver" do
         response
-        expect(LinearToonMcp::Resolvers::Team).to have_received(:call).with(client, value: team_id)
+        expect(LinearToonMcp::Resolvers::Team).to have_received(:call).with(value: team_id)
       end
     end
 
@@ -106,15 +107,6 @@ RSpec.describe LinearToonMcp::Tools::ListProjects do
       it "returns an error response" do
         expect(response).to be_a(MCP::Tool::Response).and be_error
         expect(response.content.first[:text]).to include("Unexpected response")
-      end
-    end
-
-    context "when server_context has no client" do
-      subject(:response) { described_class.call(server_context: {}) }
-
-      it "returns an error response" do
-        expect(response).to be_a(MCP::Tool::Response).and be_error
-        expect(response.content.first[:text]).to include("client missing")
       end
     end
 

--- a/spec/linear_toon_mcp/tools/list_spec.rb
+++ b/spec/linear_toon_mcp/tools/list_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+RSpec.describe LinearToonMcp::Tools::List do
+  let(:client) { instance_double(LinearToonMcp::Client) }
+
+  before { LinearToonMcp.client = client }
+
+  describe "conventions derived from class name" do
+    it "camelCases the leading word, dropping the List prefix" do
+      expect(LinearToonMcp::Tools::ListTeams.connection_name).to eq("teams")
+      expect(LinearToonMcp::Tools::ListIssueLabels.connection_name).to eq("issueLabels")
+      expect(LinearToonMcp::Tools::ListUsers.connection_name).to eq("users")
+    end
+  end
+
+  describe "DSL overrides" do
+    it "honors an explicit connection name" do
+      expect(LinearToonMcp::Tools::ListIssueStatuses.connection_name).to eq("workflowStates")
+    end
+  end
+
+  describe "#perform" do
+    let(:tool) do
+      Class.new(described_class) do
+        const_set(:QUERY, "query { things { nodes { id } } }")
+        connection :things
+      end
+    end
+
+    it "queries and extracts the connection field" do
+      allow(client).to receive(:query).and_return("things" => {"nodes" => [{"id" => "1"}]})
+      expect(tool.new.perform).to eq("nodes" => [{"id" => "1"}])
+    end
+
+    it "raises when the connection field is missing" do
+      allow(client).to receive(:query).and_return({})
+      expect { tool.new.perform }.to raise_error(LinearToonMcp::Error, /missing things field/)
+    end
+  end
+end

--- a/spec/linear_toon_mcp/tools/list_teams_spec.rb
+++ b/spec/linear_toon_mcp/tools/list_teams_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe LinearToonMcp::Tools::ListTeams do
   describe ".call" do
-    subject(:response) { described_class.call(server_context: {client:}) }
+    subject(:response) { described_class.call }
 
     let(:client) { instance_double(LinearToonMcp::Client) }
     let(:teams_data) do
@@ -15,12 +15,13 @@ RSpec.describe LinearToonMcp::Tools::ListTeams do
     end
 
     before do
+      LinearToonMcp.client = client
       allow(client).to receive(:query).and_return("teams" => teams_data)
     end
 
     it "queries all teams" do
       response
-      expect(client).to have_received(:query).with(described_class::QUERY)
+      expect(client).to have_received(:query).with(described_class::QUERY, variables: {})
     end
 
     it "returns a TOON-encoded response" do
@@ -51,15 +52,6 @@ RSpec.describe LinearToonMcp::Tools::ListTeams do
       it "returns an error response" do
         expect(response).to be_a(MCP::Tool::Response).and be_error
         expect(response.content.first[:text]).to include("Unexpected response")
-      end
-    end
-
-    context "when server_context has no client" do
-      subject(:response) { described_class.call(server_context: {}) }
-
-      it "returns an error response" do
-        expect(response).to be_a(MCP::Tool::Response).and be_error
-        expect(response.content.first[:text]).to include("client missing")
       end
     end
 

--- a/spec/linear_toon_mcp/tools/list_users_spec.rb
+++ b/spec/linear_toon_mcp/tools/list_users_spec.rb
@@ -16,12 +16,13 @@ RSpec.describe LinearToonMcp::Tools::ListUsers do
     end
 
     before do
+      LinearToonMcp.client = client
       allow(client).to receive(:query).and_return("users" => users_data)
     end
 
     it "queries all users" do
       response
-      expect(client).to have_received(:query).with(described_class::QUERY)
+      expect(client).to have_received(:query).with(described_class::QUERY, variables: {})
     end
 
     it "returns a TOON-encoded response" do
@@ -38,14 +39,14 @@ RSpec.describe LinearToonMcp::Tools::ListUsers do
       let(:team_id) { "12345678-1234-1234-1234-123456789012" }
 
       before do
-        allow(LinearToonMcp::Resolvers::Team).to receive(:call).with(client, value: "Engineering").and_return(team_id)
+        allow(LinearToonMcp::Resolvers::Team).to receive(:call).with(value: "Engineering").and_return(team_id)
         allow(client).to receive(:query).with(described_class::TEAM_MEMBERS_QUERY, variables: {id: team_id})
           .and_return("team" => {"members" => users_data})
       end
 
       it "resolves the team and queries team members" do
         response
-        expect(LinearToonMcp::Resolvers::Team).to have_received(:call).with(client, value: "Engineering")
+        expect(LinearToonMcp::Resolvers::Team).to have_received(:call).with(value: "Engineering")
         expect(client).to have_received(:query).with(
           described_class::TEAM_MEMBERS_QUERY,
           variables: {id: team_id}
@@ -64,14 +65,14 @@ RSpec.describe LinearToonMcp::Tools::ListUsers do
       let(:team_id) { "12345678-1234-1234-1234-123456789012" }
 
       before do
-        allow(LinearToonMcp::Resolvers::Team).to receive(:call).with(client, value: team_id).and_return(team_id)
+        allow(LinearToonMcp::Resolvers::Team).to receive(:call).with(value: team_id).and_return(team_id)
         allow(client).to receive(:query).with(described_class::TEAM_MEMBERS_QUERY, variables: {id: team_id})
           .and_return("team" => {"members" => users_data})
       end
 
       it "passes UUID through the resolver" do
         response
-        expect(LinearToonMcp::Resolvers::Team).to have_received(:call).with(client, value: team_id)
+        expect(LinearToonMcp::Resolvers::Team).to have_received(:call).with(value: team_id)
       end
     end
 
@@ -123,15 +124,6 @@ RSpec.describe LinearToonMcp::Tools::ListUsers do
       it "returns an error response" do
         expect(response).to be_a(MCP::Tool::Response).and be_error
         expect(response.content.first[:text]).to include("Unexpected response")
-      end
-    end
-
-    context "when server_context has no client" do
-      subject(:response) { described_class.call(server_context: {}) }
-
-      it "returns an error response" do
-        expect(response).to be_a(MCP::Tool::Response).and be_error
-        expect(response.content.first[:text]).to include("client missing")
       end
     end
 

--- a/spec/linear_toon_mcp/tools/update_issue_spec.rb
+++ b/spec/linear_toon_mcp/tools/update_issue_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe LinearToonMcp::Tools::UpdateIssue do
     end
 
     before do
+      LinearToonMcp.client = client
       allow(client).to receive(:query).and_return(
         "issueUpdate" => {"success" => true, "issue" => issue_data}
       )
@@ -80,9 +81,9 @@ RSpec.describe LinearToonMcp::Tools::UpdateIssue do
       let(:params) { {id: issue_id, team: "Engineering", assignee: "Alice", state: "Done"} }
 
       before do
-        allow(LinearToonMcp::Resolvers::Team).to receive(:call).with(client, value: "Engineering").and_return("team-uuid")
-        allow(LinearToonMcp::Resolvers::User).to receive(:call).with(client, value: "Alice").and_return("user-uuid")
-        allow(LinearToonMcp::Resolvers::WorkflowState).to receive(:call).with(client, value: "Done", team_id: "team-uuid").and_return("state-uuid")
+        allow(LinearToonMcp::Resolvers::Team).to receive(:call).with(value: "Engineering").and_return("team-uuid")
+        allow(LinearToonMcp::Resolvers::User).to receive(:call).with(value: "Alice").and_return("user-uuid")
+        allow(LinearToonMcp::Resolvers::WorkflowState).to receive(:call).with(value: "Done", team_id: "team-uuid").and_return("state-uuid")
       end
 
       it "resolves names to IDs" do
@@ -101,7 +102,7 @@ RSpec.describe LinearToonMcp::Tools::UpdateIssue do
         allow(client).to receive(:query).with(described_class::ISSUE_TEAM_QUERY, variables: {id: issue_id})
           .and_return("issue" => {"team" => {"id" => "fetched-team-uuid"}})
         allow(LinearToonMcp::Resolvers::IssueLabel).to receive(:call_many)
-          .with(client, values: ["Bug"], team_id: "fetched-team-uuid").and_return(["label-uuid"])
+          .with(values: ["Bug"], team_id: "fetched-team-uuid").and_return(["label-uuid"])
         allow(client).to receive(:query).with(described_class::MUTATION, anything)
           .and_return("issueUpdate" => {"success" => true, "issue" => issue_data})
       end
@@ -109,7 +110,7 @@ RSpec.describe LinearToonMcp::Tools::UpdateIssue do
       it "fetches issue team and resolves labels scoped to it" do
         response
         expect(client).to have_received(:query).with(described_class::ISSUE_TEAM_QUERY, variables: {id: issue_id})
-        expect(LinearToonMcp::Resolvers::IssueLabel).to have_received(:call_many).with(client, values: ["Bug"], team_id: "fetched-team-uuid")
+        expect(LinearToonMcp::Resolvers::IssueLabel).to have_received(:call_many).with(values: ["Bug"], team_id: "fetched-team-uuid")
       end
     end
 
@@ -119,7 +120,7 @@ RSpec.describe LinearToonMcp::Tools::UpdateIssue do
       before do
         allow(client).to receive(:query).with(described_class::ISSUE_TEAM_QUERY, variables: {id: issue_id})
           .and_return("issue" => {"team" => {"id" => "fetched-team-uuid"}})
-        allow(LinearToonMcp::Resolvers::WorkflowState).to receive(:call).with(client, value: "Done", team_id: "fetched-team-uuid").and_return("state-uuid")
+        allow(LinearToonMcp::Resolvers::WorkflowState).to receive(:call).with(value: "Done", team_id: "fetched-team-uuid").and_return("state-uuid")
         allow(client).to receive(:query).with(described_class::MUTATION, anything)
           .and_return("issueUpdate" => {"success" => true, "issue" => issue_data})
       end
@@ -409,15 +410,6 @@ RSpec.describe LinearToonMcp::Tools::UpdateIssue do
       it "returns an error response" do
         expect(response).to be_a(MCP::Tool::Response).and be_error
         expect(response.content.first[:text]).to include("failed")
-      end
-    end
-
-    context "when server_context has no client" do
-      subject(:response) { described_class.call(**params, server_context: {}) }
-
-      it "returns an error response" do
-        expect(response).to be_a(MCP::Tool::Response).and be_error
-        expect(response.content.first[:text]).to include("client missing")
       end
     end
 

--- a/spec/linear_toon_mcp/tools/update_spec.rb
+++ b/spec/linear_toon_mcp/tools/update_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+RSpec.describe LinearToonMcp::Tools::Update do
+  let(:client) { instance_double(LinearToonMcp::Client) }
+
+  before { LinearToonMcp.client = client }
+
+  describe "conventions derived from class name" do
+    it "camelCases the entity from the class name, dropping the Update prefix" do
+      expect(LinearToonMcp::Tools::UpdateIssue.entity_name).to eq("issue")
+    end
+
+    it "appends Update to the entity for the mutation field" do
+      expect(LinearToonMcp::Tools::UpdateIssue.mutation_name).to eq("issueUpdate")
+    end
+
+    it "uses the stripped class name as the entity label" do
+      expect(LinearToonMcp::Tools::UpdateIssue.entity_label).to eq("Issue")
+    end
+  end
+
+  describe "#perform" do
+    let(:tool) do
+      Class.new(described_class) do
+        const_set(:MUTATION, "mutation { thingUpdate { success thing { id } } }")
+
+        class << self
+          def entity_name
+            "thing"
+          end
+
+          def mutation_name
+            "thingUpdate"
+          end
+
+          def entity_label
+            "Thing"
+          end
+        end
+
+        def variables(id:, **)
+          {id:, input: {}}
+        end
+      end
+    end
+
+    it "submits the mutation and returns the updated entity" do
+      allow(client).to receive(:query)
+        .and_return("thingUpdate" => {"success" => true, "thing" => {"id" => "1"}})
+      expect(tool.new.perform(id: "1")).to eq("id" => "1")
+    end
+
+    it "raises when the mutation payload is missing" do
+      allow(client).to receive(:query).and_return({})
+      expect { tool.new.perform(id: "1") }
+        .to raise_error(LinearToonMcp::Error, /Thing update failed: no result returned/)
+    end
+
+    it "raises when success is false" do
+      allow(client).to receive(:query)
+        .and_return("thingUpdate" => {"success" => false, "thing" => nil})
+      expect { tool.new.perform(id: "1") }
+        .to raise_error(LinearToonMcp::Error, /\AThing update failed\z/)
+    end
+  end
+end

--- a/spec/linear_toon_mcp_spec.rb
+++ b/spec/linear_toon_mcp_spec.rb
@@ -4,4 +4,20 @@ RSpec.describe LinearToonMcp do
   it "has a version number" do
     expect(LinearToonMcp::VERSION).not_to be_nil
   end
+
+  describe ".client" do
+    let(:injected) { instance_double(LinearToonMcp::Client) }
+
+    it "returns the assigned client" do
+      described_class.client = injected
+      expect(described_class.client).to eq(injected)
+    end
+
+    it "lazily instantiates a Client when unset" do
+      described_class.client = nil
+      built = instance_double(LinearToonMcp::Client)
+      allow(LinearToonMcp::Client).to receive(:new).and_return(built)
+      expect(described_class.client).to eq(built)
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,10 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
+  config.before do
+    LinearToonMcp.instance_variable_set(:@client, nil)
+  end
+
   config.order = :random
   Kernel.srand config.seed
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,7 @@ RSpec.configure do |config|
   end
 
   config.before do
-    LinearToonMcp.instance_variable_set(:@client, nil)
+    LinearToonMcp.client = nil
   end
 
   config.order = :random


### PR DESCRIPTION
## Summary

Refactors all 13 MCP tools onto a CRUD verb hierarchy, mirroring the resolver refactor pattern from #38. Each tool sheds its envelope boilerplate (client extract, error rescue, TOON encode) and inherits convention-driven behaviour from its verb base. Net -292 lines across 39 files.

## Verb hierarchy

```
Tools::Base                 # envelope: rescue Error, TOON-encode, success/error response
├── Tools::List             # connection-field extraction (data["teams"]["nodes"])
├── Tools::Get              # entity-field extraction (data["issue"], not-found message)
├── Tools::Create           # mutation submit, success check, return entity
└── Tools::Update           # like Create with {id:, input:} payload
```

Conventions derived from the class name:

- `ListTeams` → connection `teams`
- `ListIssueLabels` → connection `issueLabels`
- `ListIssueStatuses` overrides via `connection :workflowStates`
- `GetIssue` → entity `issue`, not-found "Issue not found: …"
- `CreateIssue` → mutation `issueCreate`, return key `issue`
- `UpdateIssue` → mutation `issueUpdate`, return key `issue`

Tools::Delete slots in trivially when #41 introduces `delete_comment`.

## Module-level client

`LinearToonMcp.client` replaces `server_context: {client:}` threading. Lazy-initialised from `LINEAR_API_KEY` on first access; assignable for tests. Tools and resolvers read it directly — no positional plumbing.

`Resolvers::Base.call` signature drops the client positional:

```ruby
# before
Resolvers::Team.call(client, value: "Engineering")
Resolvers::IssueLabel.call_many(client, values: labels, team_id:)

# after
Resolvers::Team.call(value: "Engineering")
Resolvers::IssueLabel.call_many(values: labels, team_id:)
```

## What didn't change

- The MCP surface (tool names, descriptions, input schemas, response shape) — verified via stdio smoke test against the live Linear API
- `ListIssues` inline filter resolution remains as-is. Folding it onto `Resolvers::*` (per the handoff) is a behavior tightening worth its own sub-issue; the verb migration is mechanical, the filter cleanup involves a tighter team-required contract on `state:`/`cycle:` lookups

## Test plan

- [x] `bundle exec rspec` — 218 examples, 0 failures
- [x] `bundle exec standardrb` — clean
- [x] Smoke test via stdio with the local gem build:
  - `initialize` handshake returns server info
  - `tools/list` lists all 13 tools
  - `list_teams` returns live team data (BRI, VIB)
  - `list_issue_statuses team=VIB` resolves team key → team_id → returns 8 states including the `duplicate` type
  - `get_issue id=VIB-1` returns an MCP error response from the GraphQL error path
  - `list_issues team=VIB limit=2` returns connection shape with pageInfo

Closes #45.
